### PR TITLE
feat/api-keys-management

### DIFF
--- a/backend/src/main/java/com/delivera/controller/ApiKeyController.java
+++ b/backend/src/main/java/com/delivera/controller/ApiKeyController.java
@@ -7,7 +7,7 @@ import com.delivera.service.ApiKeyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,11 +17,11 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/settings/api-keys")
+@RequiredArgsConstructor
 @Tag(name = "API Keys", description = "Gestión de API keys de empresa")
 public class ApiKeyController {
 
-    @Autowired
-    private ApiKeyService apiKeyService;
+    private final ApiKeyService apiKeyService;
 
     @Operation(summary = "Listar API keys")
     @GetMapping

--- a/backend/src/main/java/com/delivera/controller/ApiKeyController.java
+++ b/backend/src/main/java/com/delivera/controller/ApiKeyController.java
@@ -1,0 +1,44 @@
+package com.delivera.controller;
+
+import com.delivera.dto.settings.ApiKeyCreateRequest;
+import com.delivera.dto.settings.ApiKeyCreatedResponse;
+import com.delivera.dto.settings.ApiKeyResponse;
+import com.delivera.service.ApiKeyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/settings/api-keys")
+@Tag(name = "API Keys", description = "Gestión de API keys de empresa")
+public class ApiKeyController {
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Operation(summary = "Listar API keys")
+    @GetMapping
+    public ResponseEntity<List<ApiKeyResponse>> list() {
+        return ResponseEntity.ok(apiKeyService.list());
+    }
+
+    @Operation(summary = "Generar nueva API key")
+    @PostMapping
+    public ResponseEntity<ApiKeyCreatedResponse> create(@Valid @RequestBody ApiKeyCreateRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(apiKeyService.create(req));
+    }
+
+    @Operation(summary = "Revocar una API key")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> revoke(@PathVariable UUID id) {
+        apiKeyService.revoke(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/delivera/dto/settings/ApiKeyCreateRequest.java
+++ b/backend/src/main/java/com/delivera/dto/settings/ApiKeyCreateRequest.java
@@ -1,0 +1,9 @@
+package com.delivera.dto.settings;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ApiKeyCreateRequest(
+        @NotBlank @Size(max = 100)
+        String name
+) {}

--- a/backend/src/main/java/com/delivera/dto/settings/ApiKeyCreatedResponse.java
+++ b/backend/src/main/java/com/delivera/dto/settings/ApiKeyCreatedResponse.java
@@ -1,0 +1,12 @@
+package com.delivera.dto.settings;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ApiKeyCreatedResponse(
+        UUID id,
+        String name,
+        String prefix,
+        String token,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/delivera/dto/settings/ApiKeyResponse.java
+++ b/backend/src/main/java/com/delivera/dto/settings/ApiKeyResponse.java
@@ -1,0 +1,13 @@
+package com.delivera.dto.settings;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ApiKeyResponse(
+        UUID id,
+        String name,
+        String prefix,
+        Instant createdAt,
+        Instant revokedAt,
+        Instant lastUsedAt
+) {}

--- a/backend/src/main/java/com/delivera/exception/ApiKeyNotFoundException.java
+++ b/backend/src/main/java/com/delivera/exception/ApiKeyNotFoundException.java
@@ -1,0 +1,7 @@
+package com.delivera.exception;
+
+public class ApiKeyNotFoundException extends RuntimeException {
+    public ApiKeyNotFoundException() {
+        super("API key not found");
+    }
+}

--- a/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
@@ -43,7 +43,8 @@ public class GlobalExceptionHandler {
         Map.entry(LastAdminException.class,                 new Mapping(CONFLICT,             "LAST_ADMIN")),
         Map.entry(LoyalUserCannotBeWorkerException.class,   new Mapping(CONFLICT,             "LOYAL_USER_CANNOT_BE_WORKER")),
         Map.entry(MissingRecipientAddressException.class, new Mapping(UNPROCESSABLE_ENTITY, "MISSING_RECIPIENT_ADDRESS")),
-        Map.entry(RateLimitExceededException.class,       new Mapping(TOO_MANY_REQUESTS,    "RATE_LIMIT_EXCEEDED"))
+        Map.entry(RateLimitExceededException.class,       new Mapping(TOO_MANY_REQUESTS,    "RATE_LIMIT_EXCEEDED")),
+        Map.entry(ApiKeyNotFoundException.class,          new Mapping(NOT_FOUND,            "API_KEY_NOT_FOUND"))
     );
 
     @ExceptionHandler(RuntimeException.class)

--- a/backend/src/main/java/com/delivera/model/ApiKey.java
+++ b/backend/src/main/java/com/delivera/model/ApiKey.java
@@ -1,0 +1,43 @@
+package com.delivera.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "api_keys")
+public class ApiKey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 16)
+    private String prefix;
+
+    @Column(name = "key_hash", nullable = false, unique = true, length = 128)
+    private String keyHash;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+}

--- a/backend/src/main/java/com/delivera/repository/ApiKeyRepository.java
+++ b/backend/src/main/java/com/delivera/repository/ApiKeyRepository.java
@@ -1,0 +1,17 @@
+package com.delivera.repository;
+
+import com.delivera.model.ApiKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
+
+    List<ApiKey> findByCompanyIdOrderByCreatedAtDesc(UUID companyId);
+
+    Optional<ApiKey> findByIdAndCompanyId(UUID id, UUID companyId);
+
+    Optional<ApiKey> findByKeyHash(String keyHash);
+}

--- a/backend/src/main/java/com/delivera/service/ApiKeyService.java
+++ b/backend/src/main/java/com/delivera/service/ApiKeyService.java
@@ -10,7 +10,7 @@ import com.delivera.model.Company;
 import com.delivera.repository.ApiKeyRepository;
 import com.delivera.repository.CompanyRepository;
 import com.delivera.security.SecurityUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,18 +24,17 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class ApiKeyService {
 
     private static final String TOKEN_PREFIX = "dlv_";
     private static final int RANDOM_BYTES = 32;
     private static final int VISIBLE_PREFIX_LENGTH = 12;
+    private static final SecureRandom RANDOM = new SecureRandom();
 
-    @Autowired
-    private ApiKeyRepository apiKeyRepository;
-    @Autowired
-    private CompanyRepository companyRepository;
-    @Autowired
-    private SecurityUtils securityUtils;
+    private final ApiKeyRepository apiKeyRepository;
+    private final CompanyRepository companyRepository;
+    private final SecurityUtils securityUtils;
 
     @Transactional(readOnly = true)
     public List<ApiKeyResponse> list() {
@@ -73,7 +72,7 @@ public class ApiKeyService {
 
     private String generateToken() {
         byte[] bytes = new byte[RANDOM_BYTES];
-        new SecureRandom().nextBytes(bytes);
+        RANDOM.nextBytes(bytes);
         return TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 

--- a/backend/src/main/java/com/delivera/service/ApiKeyService.java
+++ b/backend/src/main/java/com/delivera/service/ApiKeyService.java
@@ -1,0 +1,92 @@
+package com.delivera.service;
+
+import com.delivera.dto.settings.ApiKeyCreateRequest;
+import com.delivera.dto.settings.ApiKeyCreatedResponse;
+import com.delivera.dto.settings.ApiKeyResponse;
+import com.delivera.exception.ApiKeyNotFoundException;
+import com.delivera.exception.CompanyContextException;
+import com.delivera.model.ApiKey;
+import com.delivera.model.Company;
+import com.delivera.repository.ApiKeyRepository;
+import com.delivera.repository.CompanyRepository;
+import com.delivera.security.SecurityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ApiKeyService {
+
+    private static final String TOKEN_PREFIX = "dlv_";
+    private static final int RANDOM_BYTES = 32;
+    private static final int VISIBLE_PREFIX_LENGTH = 12;
+
+    @Autowired
+    private ApiKeyRepository apiKeyRepository;
+    @Autowired
+    private CompanyRepository companyRepository;
+    @Autowired
+    private SecurityUtils securityUtils;
+
+    @Transactional(readOnly = true)
+    public List<ApiKeyResponse> list() {
+        return apiKeyRepository.findByCompanyIdOrderByCreatedAtDesc(securityUtils.getCurrentCompanyId())
+                .stream().map(this::toResponse).toList();
+    }
+
+    @Transactional
+    public ApiKeyCreatedResponse create(ApiKeyCreateRequest req) {
+        Company company = companyRepository.findById(securityUtils.getCurrentCompanyId())
+                .orElseThrow(CompanyContextException::new);
+
+        String token = generateToken();
+        String prefix = token.substring(0, VISIBLE_PREFIX_LENGTH);
+
+        ApiKey key = new ApiKey();
+        key.setCompany(company);
+        key.setName(req.name());
+        key.setPrefix(prefix);
+        key.setKeyHash(hash(token));
+        apiKeyRepository.save(key);
+
+        return new ApiKeyCreatedResponse(key.getId(), key.getName(), key.getPrefix(), token, Instant.now());
+    }
+
+    @Transactional
+    public void revoke(UUID id) {
+        ApiKey key = apiKeyRepository.findByIdAndCompanyId(id, securityUtils.getCurrentCompanyId())
+                .orElseThrow(ApiKeyNotFoundException::new);
+        if (key.getRevokedAt() == null) {
+            key.setRevokedAt(Instant.now());
+            apiKeyRepository.save(key);
+        }
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[RANDOM_BYTES];
+        new SecureRandom().nextBytes(bytes);
+        return TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    static String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(token.getBytes()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private ApiKeyResponse toResponse(ApiKey k) {
+        return new ApiKeyResponse(k.getId(), k.getName(), k.getPrefix(), k.getCreatedAt(), k.getRevokedAt(), k.getLastUsedAt());
+    }
+}

--- a/backend/src/main/resources/db/migration/V41__api_keys.sql
+++ b/backend/src/main/resources/db/migration/V41__api_keys.sql
@@ -1,0 +1,13 @@
+CREATE TABLE api_keys (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id  UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    name        VARCHAR(100) NOT NULL,
+    prefix      VARCHAR(16)  NOT NULL,
+    key_hash    VARCHAR(128) NOT NULL UNIQUE,
+    created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at  TIMESTAMP,
+    last_used_at TIMESTAMP
+);
+
+CREATE INDEX idx_api_keys_company ON api_keys(company_id);
+CREATE INDEX idx_api_keys_prefix  ON api_keys(prefix);

--- a/backend/src/test/java/com/delivera/service/ApiKeyServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/ApiKeyServiceTest.java
@@ -1,0 +1,114 @@
+package com.delivera.service;
+
+import com.delivera.dto.settings.ApiKeyCreateRequest;
+import com.delivera.dto.settings.ApiKeyCreatedResponse;
+import com.delivera.exception.ApiKeyNotFoundException;
+import com.delivera.model.ApiKey;
+import com.delivera.model.Company;
+import com.delivera.repository.ApiKeyRepository;
+import com.delivera.repository.CompanyRepository;
+import com.delivera.security.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApiKeyServiceTest {
+
+    @Mock private ApiKeyRepository apiKeyRepository;
+    @Mock private CompanyRepository companyRepository;
+    @Mock private SecurityUtils securityUtils;
+    @InjectMocks private ApiKeyService apiKeyService;
+
+    private UUID companyId;
+    private Company company;
+
+    @BeforeEach
+    void setUp() {
+        companyId = UUID.randomUUID();
+        company = new Company();
+        company.setId(companyId);
+        company.setName("Acme");
+        when(securityUtils.getCurrentCompanyId()).thenReturn(companyId);
+    }
+
+    @Test
+    void createGeneratesUniqueTokenAndStoresHash() {
+        when(companyRepository.findById(companyId)).thenReturn(Optional.of(company));
+
+        ApiKeyCreatedResponse res = apiKeyService.create(new ApiKeyCreateRequest("ERP"));
+
+        assertThat(res.token()).startsWith("dlv_");
+        assertThat(res.prefix()).hasSize(12);
+        assertThat(res.token()).startsWith(res.prefix());
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        ApiKey saved = captor.getValue();
+        assertThat(saved.getName()).isEqualTo("ERP");
+        assertThat(saved.getCompany()).isSameAs(company);
+        assertThat(saved.getKeyHash()).isEqualTo(ApiKeyService.hash(res.token()));
+        assertThat(saved.getKeyHash()).isNotEqualTo(res.token());
+    }
+
+    @Test
+    void listReturnsKeysForCurrentCompany() {
+        ApiKey k = new ApiKey();
+        k.setName("k1");
+        when(apiKeyRepository.findByCompanyIdOrderByCreatedAtDesc(companyId)).thenReturn(List.of(k));
+
+        var list = apiKeyService.list();
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).name()).isEqualTo("k1");
+    }
+
+    @Test
+    void revokeMarksKeyAsRevoked() {
+        UUID id = UUID.randomUUID();
+        ApiKey k = new ApiKey();
+        k.setId(id);
+        when(apiKeyRepository.findByIdAndCompanyId(id, companyId)).thenReturn(Optional.of(k));
+
+        apiKeyService.revoke(id);
+
+        assertThat(k.getRevokedAt()).isNotNull();
+        verify(apiKeyRepository).save(k);
+    }
+
+    @Test
+    void revokeIsIdempotent() {
+        UUID id = UUID.randomUUID();
+        ApiKey k = new ApiKey();
+        Instant earlier = Instant.now().minusSeconds(60);
+        k.setRevokedAt(earlier);
+        when(apiKeyRepository.findByIdAndCompanyId(id, companyId)).thenReturn(Optional.of(k));
+
+        apiKeyService.revoke(id);
+
+        assertThat(k.getRevokedAt()).isEqualTo(earlier);
+        verify(apiKeyRepository, never()).save(any());
+    }
+
+    @Test
+    void revokeMissingKeyThrows() {
+        UUID id = UUID.randomUUID();
+        when(apiKeyRepository.findByIdAndCompanyId(id, companyId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> apiKeyService.revoke(id))
+                .isInstanceOf(ApiKeyNotFoundException.class);
+    }
+}

--- a/frontend/src/__tests__/ApiKeysSection.spec.js
+++ b/frontend/src/__tests__/ApiKeysSection.spec.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ApiKeysSection from '@/views/profile/ApiKeysSection.vue'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockDel = vi.fn()
+const mockTranslateError = vi.fn(() => 'translated')
+
+vi.mock('@/composables/useApi', () => ({
+  useApi: () => ({ get: mockGet, post: mockPost, del: mockDel, translateError: mockTranslateError }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (k) => k, locale: { value: 'es' } }),
+}))
+
+vi.mock('@/composables/useFormatDate', () => ({
+  useFormatDate: () => ({ formatDate: (v) => v, formatDateTime: (v) => v }),
+}))
+
+const stubs = { PMessage: true, PButton: true, InputText: true }
+
+function makeWrapper() {
+  return mount(ApiKeysSection, { global: { stubs } })
+}
+
+beforeEach(() => {
+  mockGet.mockReset()
+  mockPost.mockReset()
+  mockDel.mockReset()
+  mockGet.mockResolvedValue({ ok: true, json: async () => [] })
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe('ApiKeysSection', () => {
+  it('loads keys on mount', async () => {
+    const w = makeWrapper()
+    await flushPromises()
+    expect(mockGet).toHaveBeenCalledWith('/settings/api-keys')
+    expect(w.text()).toContain('apiKeys.empty')
+  })
+
+  it('shows error message when load fails', async () => {
+    mockGet.mockResolvedValueOnce({ ok: false })
+    makeWrapper()
+    await flushPromises()
+    expect(mockGet).toHaveBeenCalled()
+  })
+
+  it('renders existing keys with active status', async () => {
+    mockGet.mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: '1', name: 'k1', prefix: 'dlv_abc', createdAt: '2026-01-01', revokedAt: null, lastUsedAt: null },
+    ] })
+    const w = makeWrapper()
+    await flushPromises()
+    expect(w.text()).toContain('k1')
+    expect(w.text()).toContain('dlv_abc')
+    expect(w.text()).toContain('apiKeys.active')
+  })
+
+  it('marks revoked keys as revoked and hides revoke button', async () => {
+    mockGet.mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: '1', name: 'k1', prefix: 'dlv_abc', createdAt: '2026-01-01', revokedAt: '2026-02-01', lastUsedAt: '2026-01-15' },
+    ] })
+    const w = makeWrapper()
+    await flushPromises()
+    expect(w.text()).toContain('apiKeys.revoked')
+    expect(w.text()).toContain('apiKeys.lastUsed')
+  })
+
+  it('creates a new key and reloads list', async () => {
+    mockPost.mockResolvedValueOnce({ ok: true, json: async () => ({ id: '2', name: 'New', prefix: 'dlv_xyz', token: 'dlv_full_token' }) })
+    const w = makeWrapper()
+    await flushPromises()
+
+    w.vm.newKeyName = 'New'
+    await w.vm.submitCreate()
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith('/settings/api-keys', { name: 'New' })
+    expect(w.vm.createdToken.token).toBe('dlv_full_token')
+  })
+
+  it('does not create when name is blank', async () => {
+    const w = makeWrapper()
+    await flushPromises()
+    w.vm.newKeyName = '   '
+    await w.vm.submitCreate()
+    expect(mockPost).not.toHaveBeenCalled()
+    expect(w.vm.createError).toBeTruthy()
+  })
+
+  it('revokes a key and reloads list', async () => {
+    mockGet.mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: 'k', name: 'k1', prefix: 'dlv_a', createdAt: '2026-01-01' },
+    ] })
+    mockDel.mockResolvedValueOnce({ ok: true })
+    const w = makeWrapper()
+    await flushPromises()
+
+    await w.vm.revoke('k')
+    expect(mockDel).toHaveBeenCalledWith('/settings/api-keys/k')
+  })
+
+  it('copies token to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue()
+    Object.assign(navigator, { clipboard: { writeText } })
+    const w = makeWrapper()
+    await flushPromises()
+    w.vm.createdToken = { token: 'dlv_xxx', name: 'n', prefix: 'dlv_xxx' }
+    await w.vm.copyToken()
+    expect(writeText).toHaveBeenCalledWith('dlv_xxx')
+    expect(w.vm.tokenCopied).toBe(true)
+  })
+
+  it('exposes start/cancel/dismiss helpers', async () => {
+    const w = makeWrapper()
+    await flushPromises()
+    w.vm.startCreate()
+    expect(w.vm.creating).toBe(true)
+    w.vm.cancelCreate()
+    expect(w.vm.creating).toBe(false)
+    w.vm.createdToken = { token: 't' }
+    w.vm.dismissCreated()
+    expect(w.vm.createdToken).toBe(null)
+  })
+})

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -441,6 +441,7 @@ settings:
   orgSection: Organization
   companySection: Company
   subscriptionSection: Plan
+  apiKeysSection: API keys
   currentPlan: Current plan
   availablePlans: Available plans
   selectPlan: Switch to this plan
@@ -480,3 +481,20 @@ settings:
   noCompaniesFound: No companies found matching that criteria
   searchByName: Search by name
   filterAll: All
+
+apiKeys:
+  intro: Generate and manage keys so external systems can access the Delivera API. The key is shown only once at creation.
+  create: Create API key
+  name: Name
+  namePlaceholder: e.g. ERP integration
+  createdTitle: Your new API key
+  createdWarning: Copy it now. It will not be shown again.
+  copy: Copy
+  copied: Copied
+  empty: You haven't created any API keys yet.
+  created: Created
+  lastUsed: Last used
+  neverUsed: Never used
+  active: Active
+  revoked: Revoked
+  revoke: Revoke

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -441,6 +441,7 @@ settings:
   orgSection: Organización
   companySection: Empresa
   subscriptionSection: Plan
+  apiKeysSection: API keys
   currentPlan: Plan actual
   availablePlans: Planes disponibles
   selectPlan: Cambiar a este plan
@@ -480,3 +481,20 @@ settings:
   noCompaniesFound: No se encontraron empresas con ese criterio
   searchByName: Buscar por nombre
   filterAll: Todos
+
+apiKeys:
+  intro: Genera y gestiona claves para que sistemas externos accedan a la API de Delivera. La clave solo se muestra una vez al crearla.
+  create: Crear API key
+  name: Nombre
+  namePlaceholder: Ej. integración ERP
+  createdTitle: Tu nueva API key
+  createdWarning: Cópiala ahora. No volverá a mostrarse.
+  copy: Copiar
+  copied: Copiada
+  empty: Aún no has creado ninguna API key.
+  created: Creada
+  lastUsed: Último uso
+  neverUsed: Nunca usada
+  active: Activa
+  revoked: Revocada
+  revoke: Revocar

--- a/frontend/src/views/profile/ApiKeysSection.vue
+++ b/frontend/src/views/profile/ApiKeysSection.vue
@@ -1,0 +1,196 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useApi } from '@/composables/useApi'
+import { useFormatDate } from '@/composables/useFormatDate'
+
+const { t } = useI18n()
+const api = useApi()
+const { formatDateTime } = useFormatDate()
+
+const keys = ref([])
+const loadError = ref('')
+const loading = ref(false)
+
+const creating = ref(false)
+const newKeyName = ref('')
+const createError = ref('')
+const createSaving = ref(false)
+const createdToken = ref(null)
+const tokenCopied = ref(false)
+
+const revokingId = ref(null)
+const revokeError = ref('')
+
+async function load() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const res = await api.get('/settings/api-keys')
+    if (res.ok) keys.value = await res.json()
+    else loadError.value = t('error.connection')
+  } catch {
+    loadError.value = t('error.connection')
+  } finally {
+    loading.value = false
+  }
+}
+
+function startCreate() {
+  newKeyName.value = ''
+  createError.value = ''
+  createdToken.value = null
+  creating.value = true
+}
+
+function cancelCreate() {
+  creating.value = false
+  createError.value = ''
+}
+
+async function submitCreate() {
+  const name = newKeyName.value.trim()
+  if (!name) { createError.value = t('validation.required', { field: t('apiKeys.name') }); return }
+  createSaving.value = true
+  createError.value = ''
+  try {
+    const res = await api.post('/settings/api-keys', { name })
+    if (res.ok) {
+      const data = await res.json()
+      createdToken.value = data
+      newKeyName.value = ''
+      await load()
+    } else {
+      const data = await res.json()
+      createError.value = api.translateError(data, 'error.saveFailed')
+    }
+  } catch {
+    createError.value = t('error.connection')
+  } finally {
+    createSaving.value = false
+  }
+}
+
+async function copyToken() {
+  if (!createdToken.value?.token) return
+  await navigator.clipboard.writeText(createdToken.value.token)
+  tokenCopied.value = true
+  setTimeout(() => { tokenCopied.value = false }, 2000)
+}
+
+function dismissCreated() {
+  createdToken.value = null
+  creating.value = false
+}
+
+async function revoke(id) {
+  revokingId.value = id
+  revokeError.value = ''
+  try {
+    const res = await api.del(`/settings/api-keys/${id}`)
+    if (res.ok) await load()
+    else {
+      const data = await res.json()
+      revokeError.value = api.translateError(data, 'error.saveFailed')
+    }
+  } catch {
+    revokeError.value = t('error.connection')
+  } finally {
+    revokingId.value = null
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="settings-section">
+    <p class="api-keys-intro">{{ t('apiKeys.intro') }}</p>
+
+    <PMessage v-if="loadError" severity="error" :closable="false" class="form-message">{{ loadError }}</PMessage>
+    <PMessage v-if="revokeError" severity="error" :closable="false" class="form-message">{{ revokeError }}</PMessage>
+
+    <div v-if="createdToken" class="api-key-created">
+      <p class="api-key-created-title">{{ t('apiKeys.createdTitle') }}</p>
+      <p class="api-key-created-warning"><i class="pi pi-exclamation-triangle" /> {{ t('apiKeys.createdWarning') }}</p>
+      <div class="api-key-token-row">
+        <code class="api-key-token">{{ createdToken.token }}</code>
+        <PButton :icon="tokenCopied ? 'pi pi-check' : 'pi pi-copy'" :label="tokenCopied ? t('apiKeys.copied') : t('apiKeys.copy')" size="small" @click="copyToken" />
+      </div>
+      <div class="form-actions">
+        <PButton :label="t('common.close')" severity="secondary" outlined size="small" @click="dismissCreated" />
+      </div>
+    </div>
+
+    <div v-if="!createdToken && !creating" class="add-company-trigger">
+      <PButton :label="t('apiKeys.create')" icon="pi pi-plus" size="small" @click="startCreate" />
+    </div>
+
+    <div v-if="!createdToken && creating" class="add-company-form">
+      <div class="form-field">
+        <label>{{ t('apiKeys.name') }}</label>
+        <InputText v-model="newKeyName" :placeholder="t('apiKeys.namePlaceholder')" maxlength="100" fluid />
+      </div>
+      <PMessage v-if="createError" severity="error" :closable="false" class="form-message">{{ createError }}</PMessage>
+      <div class="form-actions">
+        <PButton :label="t('common.cancel')" icon="pi pi-times" severity="secondary" outlined size="small" @click="cancelCreate" />
+        <PButton :label="t('apiKeys.create')" icon="pi pi-check" :loading="createSaving" size="small" @click="submitCreate" />
+      </div>
+    </div>
+
+    <div v-if="keys.length === 0 && !loading && !loadError" class="api-keys-empty">
+      <i class="pi pi-key" />
+      <p>{{ t('apiKeys.empty') }}</p>
+    </div>
+
+    <ul v-else class="api-keys-list">
+      <li v-for="k in keys" :key="k.id" class="api-key-item" :class="{ 'api-key-item--revoked': k.revokedAt }">
+        <div class="api-key-info">
+          <span class="api-key-name">{{ k.name }}</span>
+          <code class="api-key-prefix">{{ k.prefix }}…</code>
+          <span class="api-key-meta">
+            {{ t('apiKeys.created') }}: {{ formatDateTime(k.createdAt) }}
+            <template v-if="k.lastUsedAt"> · {{ t('apiKeys.lastUsed') }}: {{ formatDateTime(k.lastUsedAt) }}</template>
+            <template v-else> · {{ t('apiKeys.neverUsed') }}</template>
+          </span>
+        </div>
+        <div class="api-key-actions">
+          <span v-if="k.revokedAt" class="api-key-status api-key-status--revoked">{{ t('apiKeys.revoked') }}</span>
+          <span v-else class="api-key-status api-key-status--active">{{ t('apiKeys.active') }}</span>
+          <PButton
+            v-if="!k.revokedAt"
+            :label="t('apiKeys.revoke')"
+            icon="pi pi-ban"
+            severity="danger"
+            outlined
+            size="small"
+            :loading="revokingId === k.id"
+            @click="revoke(k.id)"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.api-keys-intro { color: var(--text-color-secondary); margin: 0 0 1rem; }
+.api-keys-empty { text-align: center; padding: 2rem; color: var(--text-color-secondary); }
+.api-keys-empty i { font-size: 2rem; display: block; margin-bottom: 0.5rem; }
+.api-keys-list { list-style: none; padding: 0; margin: 1rem 0 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.api-key-item { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.75rem 1rem; border: 1px solid var(--surface-border); border-radius: 8px; }
+.api-key-item--revoked { opacity: 0.6; }
+.api-key-info { display: flex; flex-direction: column; gap: 0.25rem; min-width: 0; }
+.api-key-name { font-weight: 600; }
+.api-key-prefix { font-family: monospace; font-size: 0.85rem; color: var(--text-color-secondary); }
+.api-key-meta { font-size: 0.8rem; color: var(--text-color-secondary); }
+.api-key-actions { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0; }
+.api-key-status { font-size: 0.75rem; font-weight: 600; padding: 0.15rem 0.5rem; border-radius: 12px; text-transform: uppercase; }
+.api-key-status--active { background: var(--green-100, #d1fae5); color: var(--green-700, #047857); }
+.api-key-status--revoked { background: var(--surface-200, #e5e7eb); color: var(--text-color-secondary); }
+.api-key-created { padding: 1rem; border: 1px solid var(--primary-color); border-radius: 8px; background: var(--primary-50, #eff6ff); margin-bottom: 1rem; }
+.api-key-created-title { font-weight: 600; margin: 0 0 0.5rem; }
+.api-key-created-warning { color: var(--orange-600, #d97706); margin: 0 0 0.75rem; font-size: 0.875rem; }
+.api-key-token-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+.api-key-token { flex: 1; padding: 0.5rem; background: var(--surface-card); border: 1px solid var(--surface-border); border-radius: 4px; font-family: monospace; font-size: 0.85rem; word-break: break-all; }
+</style>

--- a/frontend/src/views/profile/ApiKeysSection.vue
+++ b/frontend/src/views/profile/ApiKeysSection.vue
@@ -128,8 +128,8 @@ onMounted(load)
 
     <div v-if="!createdToken && creating" class="add-company-form">
       <div class="form-field">
-        <label>{{ t('apiKeys.name') }}</label>
-        <InputText v-model="newKeyName" :placeholder="t('apiKeys.namePlaceholder')" maxlength="100" fluid />
+        <label for="api-key-name">{{ t('apiKeys.name') }}</label>
+        <InputText id="api-key-name" v-model="newKeyName" :placeholder="t('apiKeys.namePlaceholder')" maxlength="100" fluid />
       </div>
       <PMessage v-if="createError" severity="error" :closable="false" class="form-message">{{ createError }}</PMessage>
       <div class="form-actions">

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -8,6 +8,7 @@ import { useValidation } from '@/composables/useValidation'
 import { useActivityTypes } from '@/composables/useActivityTypes'
 import { useAppConfig } from '@/composables/useAppConfig'
 import DeleteConfirmPanel from '@/components/DeleteConfirmPanel.vue'
+import ApiKeysSection from './ApiKeysSection.vue'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -471,6 +472,7 @@ async function copyHandle() {
           <PTab :value="0">{{ t('settings.orgSection') }}</PTab>
           <PTab :value="1">{{ t('settings.companySection') }}</PTab>
           <PTab :value="2">{{ t('settings.subscriptionSection') }}</PTab>
+          <PTab :value="3">{{ t('settings.apiKeysSection') }}</PTab>
         </PTabList>
 
         <PTabPanels>
@@ -705,6 +707,11 @@ async function copyHandle() {
                 </div>
               </div>
             </div>
+          </PTabPanel>
+
+          <!-- === API Keys === -->
+          <PTabPanel :value="3">
+            <ApiKeysSection />
           </PTabPanel>
         </PTabPanels>
       </PTabs>


### PR DESCRIPTION
## Resumen
Implementa la gestión de API keys de empresa (generar, listar y revocar) para el Sprint 4 — base de la integración con sistemas externos (DSI-21.1).

## Cambios
- Migración `V41` con tabla `api_keys` (FK a `companies` ON DELETE CASCADE).
- Entidad `ApiKey`, repositorio, servicio (`ApiKeyService`) y controlador `/settings/api-keys` (solo `COMPANY_ADMIN`).
- Token con prefijo `dlv_` + 32 bytes aleatorios; se almacena solo el SHA-256, el plaintext se devuelve únicamente al crear.
- Excepción tipada `ApiKeyNotFoundException` mapeada a 404 `API_KEY_NOT_FOUND`.
- Frontend: nueva pestaña "API keys" en `SettingsView` con componente `ApiKeysSection.vue` (crear, listar prefijo + estado + último uso, revocar; aviso de copia única).
- i18n es/en para la nueva sección.
- Tests unitarios `ApiKeyServiceTest` (5 casos: creación con hash, listado, revoke, idempotencia, no encontrada).

## Verificación
- `mvn test -Dtest=ApiKeyServiceTest` → 5/5 OK
- Lint frontend (oxlint + eslint) → 0 warnings
- E2E manual contra backend reiniciado: list 200, create 201 (token `dlv_...`), revoke 204

Closes #187