### PR TITLE
feat/api-key-authentication

### DIFF
--- a/backend/src/main/java/com/delivera/config/ApiKeyAuthenticationFilter.java
+++ b/backend/src/main/java/com/delivera/config/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.delivera.config;
+
+import com.delivera.model.ApiKey;
+import com.delivera.repository.ApiKeyRepository;
+import com.delivera.service.ApiKeyService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String HEADER = "X-API-Key";
+    private static final String ROLE = "ROLE_API_KEY";
+
+    private final ApiKeyRepository apiKeyRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HEADER);
+        if (header == null || header.isBlank() || SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.trim();
+        Optional<ApiKey> found = apiKeyRepository.findByKeyHash(ApiKeyService.hash(token));
+        if (found.isEmpty() || found.get().getRevokedAt() != null) {
+            sendError(response);
+            return;
+        }
+
+        ApiKey key = found.get();
+        key.setLastUsedAt(Instant.now());
+        apiKeyRepository.save(key);
+
+        var authorities = List.of(new SimpleGrantedAuthority(ROLE));
+        var authentication = new UsernamePasswordAuthenticationToken(
+                "api-key:" + key.getId(), null, authorities);
+        authentication.setDetails(key.getCompany().getId());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendError(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), Map.of("code", "API_KEY_INVALID"));
+    }
+}

--- a/backend/src/main/java/com/delivera/config/SecurityConfig.java
+++ b/backend/src/main/java/com/delivera/config/SecurityConfig.java
@@ -38,7 +38,9 @@ public class SecurityConfig {
     private String allowedOrigins;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                   ApiKeyAuthenticationFilter apiKeyAuthenticationFilter) throws Exception {
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
@@ -94,6 +96,7 @@ public class SecurityConfig {
 
                 auth.anyRequest().denyAll();
             })
+            .addFilterBefore(apiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/delivera/service/ApiKeyService.java
+++ b/backend/src/main/java/com/delivera/service/ApiKeyService.java
@@ -76,7 +76,7 @@ public class ApiKeyService {
         return TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
-    static String hash(String token) {
+    public static String hash(String token) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             return HexFormat.of().formatHex(digest.digest(token.getBytes()));

--- a/backend/src/test/java/com/delivera/config/ApiKeyAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/delivera/config/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,125 @@
+package com.delivera.config;
+
+import com.delivera.model.ApiKey;
+import com.delivera.model.Company;
+import com.delivera.repository.ApiKeyRepository;
+import com.delivera.service.ApiKeyService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApiKeyAuthenticationFilterTest {
+
+    @Mock private ApiKeyRepository apiKeyRepository;
+    @Mock private FilterChain filterChain;
+    @InjectMocks private ApiKeyAuthenticationFilter filter;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private ApiKey keyFor(UUID companyId) {
+        Company c = new Company();
+        c.setId(companyId);
+        ApiKey k = new ApiKey();
+        k.setId(UUID.randomUUID());
+        k.setCompany(c);
+        return k;
+    }
+
+    @Test
+    void missingHeader_proceedsWithoutAuth() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilterInternal(req, res, filterChain);
+
+        verify(filterChain).doFilter(req, res);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verifyNoInteractions(apiKeyRepository);
+    }
+
+    @Test
+    void validKey_setsAuthenticationAndUpdatesLastUsedAt() throws Exception {
+        UUID companyId = UUID.randomUUID();
+        ApiKey key = keyFor(companyId);
+        when(apiKeyRepository.findByKeyHash(ApiKeyService.hash("dlv_token")))
+                .thenReturn(Optional.of(key));
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-API-Key", "dlv_token");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilterInternal(req, res, filterChain);
+
+        verify(filterChain).doFilter(req, res);
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getDetails()).isEqualTo(companyId);
+        assertThat(auth.getAuthorities()).extracting("authority").containsExactly("ROLE_API_KEY");
+        assertThat(key.getLastUsedAt()).isNotNull();
+        verify(apiKeyRepository).save(key);
+    }
+
+    @Test
+    void unknownKey_returns401() throws Exception {
+        when(apiKeyRepository.findByKeyHash(any())).thenReturn(Optional.empty());
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-API-Key", "bad");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilterInternal(req, res, filterChain);
+
+        verify(filterChain, never()).doFilter(any(), any());
+        assertThat(res.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        assertThat(res.getContentAsString()).contains("API_KEY_INVALID");
+    }
+
+    @Test
+    void revokedKey_returns401() throws Exception {
+        ApiKey key = keyFor(UUID.randomUUID());
+        key.setRevokedAt(Instant.now());
+        when(apiKeyRepository.findByKeyHash(any())).thenReturn(Optional.of(key));
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-API-Key", "revoked");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilterInternal(req, res, filterChain);
+
+        verify(filterChain, never()).doFilter(any(), any());
+        assertThat(res.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(apiKeyRepository, never()).save(any());
+    }
+
+    @Test
+    void blankHeader_proceedsWithoutAuth() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-API-Key", "  ");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilterInternal(req, res, filterChain);
+
+        verify(filterChain).doFilter(req, res);
+        verifyNoInteractions(apiKeyRepository);
+    }
+}


### PR DESCRIPTION
Autenticación por API key mediante header `X-API-Key`.

Closes #188

## Cambios
- `ApiKeyAuthenticationFilter` registrado antes de `JwtAuthenticationFilter` en la cadena de seguridad
- Valida el token contra `api_keys.key_hash` (SHA-256), rechaza claves revocadas
- Establece `ROLE_API_KEY` y companyId en el `SecurityContext`
- Actualiza `last_used_at` al autenticar correctamente
- 5 tests unitarios cubriendo flujo válido, clave desconocida, revocada, header ausente/blanco

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Nuevas Características**
  * Se habilitó autenticación mediante clave API a través del encabezado X-API-Key.
  * Validación automática que rechaza claves revocadas con error 401.
  * Seguimiento automático del último uso registrado en cada clave API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->