### PR TITLE
feat/external-order-creation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -146,7 +146,6 @@
                     <excludes>
                         <exclude>com/delivera/DeliveraApplication.class</exclude>
                         <exclude>com/delivera/config/**</exclude>
-                        <exclude>com/delivera/controller/**</exclude>
                         <exclude>com/delivera/dto/**</exclude>
                         <exclude>com/delivera/model/**</exclude>
                         <exclude>com/delivera/exception/*Exception.class</exclude>

--- a/backend/src/main/java/com/delivera/config/SecurityConfig.java
+++ b/backend/src/main/java/com/delivera/config/SecurityConfig.java
@@ -54,6 +54,9 @@ public class SecurityConfig {
                 auth.requestMatchers(HttpMethod.GET, api + "/app-config/**").permitAll();
                 auth.requestMatchers(api + "/orders/public/**").permitAll();
 
+                // API externa autenticada con API key
+                auth.requestMatchers(api + "/external/**").hasRole("API_KEY");
+
                 // Administración global
                 auth.requestMatchers(api + "/admin/**").hasRole("GLOBAL_ADMIN");
 

--- a/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
+++ b/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
@@ -1,0 +1,27 @@
+package com.delivera.controller;
+
+import com.delivera.dto.order.OrderRequest;
+import com.delivera.dto.order.OrderResponse;
+import com.delivera.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/external/orders")
+@RequiredArgsConstructor
+@Tag(name = "API externa - Pedidos", description = "Creación de pedidos desde sistemas externos mediante API key")
+public class ExternalOrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "Crear pedido desde sistema externo")
+    @PostMapping
+    public ResponseEntity<OrderResponse> create(@Valid @RequestBody OrderRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderService.create(request));
+    }
+}

--- a/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
+++ b/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
@@ -1,0 +1,39 @@
+package com.delivera.controller;
+
+import com.delivera.dto.order.OrderRequest;
+import com.delivera.dto.order.OrderResponse;
+import com.delivera.model.OrderType;
+import com.delivera.service.OrderService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalOrderControllerTest {
+
+    @Mock private OrderService orderService;
+    @InjectMocks private ExternalOrderController controller;
+
+    @Test
+    void delegatesCreationToOrderServiceAndReturns201() {
+        OrderRequest req = new OrderRequest(UUID.randomUUID(), null, "a@b.com", "John",
+                "calle", null, null, OrderType.B2C, null, null);
+        OrderResponse expected = new OrderResponse(UUID.randomUUID(), null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, null);
+        when(orderService.create(req)).thenReturn(expected);
+
+        var resp = controller.create(req);
+
+        assertThat(resp.getStatusCode().value()).isEqualTo(201);
+        assertThat(resp.getBody()).isSameAs(expected);
+        verify(orderService).create(req);
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,6 @@ sonar.java.source=21
 sonar.java.binaries=backend/target/classes
 sonar.java.libraries=backend/target/dependency
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=**/config/**,**/dto/auth/**,**/dto/common/**,**/dto/settings/**,**/dto/config/**,**/dto/loyaluser/**,**/dto/unit/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
+sonar.coverage.exclusions=**/config/**,**/controller/**,**/dto/auth/**,**/dto/common/**,**/dto/settings/**,**/dto/config/**,**/dto/loyaluser/**,**/dto/unit/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
 sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,6 @@ sonar.java.source=21
 sonar.java.binaries=backend/target/classes
 sonar.java.libraries=backend/target/dependency
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=**/config/**,**/controller/**,**/dto/auth/**,**/dto/common/**,**/dto/settings/**,**/dto/config/**,**/dto/loyaluser/**,**/dto/unit/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
+sonar.coverage.exclusions=**/config/**,**/dto/auth/**,**/dto/common/**,**/dto/settings/**,**/dto/config/**,**/dto/loyaluser/**,**/dto/unit/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
 sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
Endpoint REST externo para que sistemas terceros (ERP, plataformas de transporte) creen pedidos autenticando con API key.

Closes #189

## Cambios
- `POST /external/orders` — recibe `OrderRequest`, devuelve 201 con `OrderResponse`
- Reutiliza `OrderService.create`; el companyId se obtiene del `SecurityContext` que el filtro de API key ya popula
- Nueva regla en `SecurityConfig`: `/external/**` requiere `ROLE_API_KEY`
- Test unitario del controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Se ha agregado un nuevo endpoint de API externa para la integración de servicios terceros. Permite la creación de pedidos mediante un endpoint dedicado con autenticación basada en clave API. El servicio devuelve una confirmación con estado 201 al completarse la solicitud exitosamente, incluyendo validación completa de datos requeridos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->