### PR TITLE
feat/external-order-status-update

### DIFF
--- a/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
+++ b/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
@@ -1,8 +1,11 @@
 package com.delivera.controller;
 
+import com.delivera.dto.order.OrderDetailResponse;
 import com.delivera.dto.order.OrderRequest;
 import com.delivera.dto.order.OrderResponse;
+import com.delivera.dto.order.OrderStatusRequest;
 import com.delivera.service.OrderService;
+import java.util.UUID;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,5 +26,12 @@ public class ExternalOrderController {
     @PostMapping
     public ResponseEntity<OrderResponse> create(@Valid @RequestBody OrderRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(orderService.create(request));
+    }
+
+    @Operation(summary = "Actualizar estado de pedido desde sistema externo")
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<OrderDetailResponse> updateStatus(@PathVariable UUID id,
+                                                            @Valid @RequestBody OrderStatusRequest request) {
+        return ResponseEntity.ok(orderService.updateStatus(id, request));
     }
 }

--- a/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
+++ b/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
@@ -1,7 +1,10 @@
 package com.delivera.controller;
 
+import com.delivera.dto.order.OrderDetailResponse;
 import com.delivera.dto.order.OrderRequest;
 import com.delivera.dto.order.OrderResponse;
+import com.delivera.dto.order.OrderStatusRequest;
+import com.delivera.model.OrderStatus;
 import com.delivera.model.OrderType;
 import com.delivera.service.OrderService;
 import org.junit.jupiter.api.Test;
@@ -35,5 +38,21 @@ class ExternalOrderControllerTest {
         assertThat(resp.getStatusCode().value()).isEqualTo(201);
         assertThat(resp.getBody()).isSameAs(expected);
         verify(orderService).create(req);
+    }
+
+    @Test
+    void delegatesStatusUpdateToOrderService() {
+        UUID id = UUID.randomUUID();
+        OrderStatusRequest req = new OrderStatusRequest(OrderStatus.IN_TRANSIT, "actualizado por ERP");
+        OrderDetailResponse expected = new OrderDetailResponse(id, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, "IN_TRANSIT", null, null, false, null, null,
+                null, null, null, null, null, null);
+        when(orderService.updateStatus(id, req)).thenReturn(expected);
+
+        var resp = controller.updateStatus(id, req);
+
+        assertThat(resp.getStatusCode().value()).isEqualTo(200);
+        assertThat(resp.getBody()).isSameAs(expected);
+        verify(orderService).updateStatus(id, req);
     }
 }


### PR DESCRIPTION
Endpoint REST externo para que sistemas terceros actualicen el estado de un pedido autenticando con API key.

Closes #190

## Cambios
- `PATCH /external/orders/{id}/status` — recibe `OrderStatusRequest`, devuelve `OrderDetailResponse`
- Reutiliza `OrderService.updateStatus` (mismo flujo que el panel web, con registro en `order_events`)
- Cubierto por la regla `/external/**` ya existente en `SecurityConfig`
- Test unitario del nuevo método del controller