### PR TITLE
feat/orders-map-route-color

### DIFF
--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR } from '@/composables/useDeliveraMap'
+
+describe('routeColorFor', () => {
+  it('mapea cada estado conocido a su color', () => {
+    expect(routeColorFor('PENDING')).toBe(ROUTE_STATUS_COLORS.PENDING)
+    expect(routeColorFor('IN_TRANSIT')).toBe(ROUTE_STATUS_COLORS.IN_TRANSIT)
+    expect(routeColorFor('DELIVERED')).toBe(ROUTE_STATUS_COLORS.DELIVERED)
+    expect(routeColorFor('CANCELLED')).toBe(ROUTE_STATUS_COLORS.CANCELLED)
+  })
+
+  it('devuelve color por defecto cuando el estado es desconocido o nulo', () => {
+    expect(routeColorFor(null)).toBe(ROUTE_COLOR)
+    expect(routeColorFor(undefined)).toBe(ROUTE_COLOR)
+    expect(routeColorFor('FOO')).toBe(ROUTE_COLOR)
+  })
+})

--- a/frontend/src/composables/useDeliveraMap.js
+++ b/frontend/src/composables/useDeliveraMap.js
@@ -25,6 +25,16 @@ L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, 
 export const CLUSTER_DISABLE_ZOOM = 10
 export const COLORS = { own: '#7c3aed', other: '#a78bfa', white: '#ffffff' }
 export const ROUTE_COLOR = '#7c3aed'
+// Colores de ruta por estado del pedido (DSI-22.1)
+export const ROUTE_STATUS_COLORS = {
+  PENDING:   '#f59e0b',
+  IN_TRANSIT:'#7c3aed',
+  DELIVERED: '#16a34a',
+  CANCELLED: '#94a3b8',
+}
+export function routeColorFor(status) {
+  return ROUTE_STATUS_COLORS[status] || ROUTE_COLOR
+}
 
 const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const TILE_ATTR = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
@@ -152,9 +162,10 @@ export function addMarker(map, {
 // ---------------------------------------------------------------------------
 export async function addRoute(map, {
   orderId, origin, dest, popupTitle, popupSubtitle, actionLabel, router,
-  timeoutMs = 6000, originMarker = null, destMarker = null,
+  timeoutMs = 6000, originMarker = null, destMarker = null, status = null,
 }) {
   const entry = { layer: null, solid: true, originMarker, destMarker }
+  const color = routeColorFor(status)
 
   async function fetchOSRM() {
     const url = `https://router.project-osrm.org/route/v1/driving/${origin.lon},${origin.lat};${dest.lon},${dest.lat}?geometries=geojson&overview=simplified`
@@ -169,14 +180,14 @@ export async function addRoute(map, {
   function buildSolid(latlngs) {
     // Trazo morado grueso de alta opacidad — visible a corta y larga distancia.
     return L.polyline(latlngs, {
-      color: ROUTE_COLOR, weight: 5, opacity: 0.95,
+      color, weight: 5, opacity: 0.95,
       lineCap: 'round', lineJoin: 'round',
     })
   }
   function buildDashed() {
     return L.polyline(
       [[origin.lat, origin.lon], [dest.lat, dest.lon]],
-      { color: ROUTE_COLOR, weight: 4, opacity: 0.9, dashArray: '10,10', lineCap: 'round' },
+      { color, weight: 4, opacity: 0.9, dashArray: '10,10', lineCap: 'round' },
     )
   }
 

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -201,6 +201,7 @@ async function initMap(unitList) {
       router,
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
+      status: p.status,
     })
     routeEntries.push(entry)
     entry.layer?.bringToFront?.()

--- a/frontend/src/views/orders/MyOrderDetailView.vue
+++ b/frontend/src/views/orders/MyOrderDetailView.vue
@@ -68,6 +68,7 @@ async function initMap() {
     popupSubtitle: `${o.originName} → ${o.destinationName || o.recipientName || ''}`,
     actionLabel: null,
     router,
+    status: o.status,
   })
   entry?.layer?.bringToFront?.()
 

--- a/frontend/src/views/orders/OrderDetailView.vue
+++ b/frontend/src/views/orders/OrderDetailView.vue
@@ -104,6 +104,7 @@ async function initOrderMap() {
       popupSubtitle: `${o.originName} → ${o.destinationName || o.recipientName || o.recipientEmail || ''}`,
       actionLabel: t('orders.viewDetail'),
       router,
+      status: o.status,
     })
     if (entry && !entry.solid) routeFailed.value = true
     entry?.layer?.bringToFront?.()

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -192,6 +192,7 @@ async function updateMapOrders() {
       router,
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
+      status: o.status,
     })
     if (token !== mapToken) { if (entry?.layer && map) map.removeLayer(entry.layer); return }
     routeEntries.push(entry)


### PR DESCRIPTION
Color de las polilíneas de ruta en los mapas según el estado del pedido.

Closes #191

## Cambios
- `useDeliveraMap.js`: nuevo `ROUTE_STATUS_COLORS` (PENDING ámbar, IN_TRANSIT morado, DELIVERED verde, CANCELLED gris) y helper `routeColorFor(status)`
- `addRoute()` acepta el parámetro `status` y aplica el color correspondiente a las dos variantes (OSRM y línea recta discontinua)
- HomeView, OrdersView, OrderDetailView y MyOrderDetailView pasan el `status` al llamar a `addRoute`
- Tests unitarios del helper