### PR TITLE
feat/orders-current-location

### DIFF
--- a/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
+++ b/backend/src/main/java/com/delivera/controller/ExternalOrderController.java
@@ -1,6 +1,7 @@
 package com.delivera.controller;
 
 import com.delivera.dto.order.OrderDetailResponse;
+import com.delivera.dto.order.OrderLocationRequest;
 import com.delivera.dto.order.OrderRequest;
 import com.delivera.dto.order.OrderResponse;
 import com.delivera.dto.order.OrderStatusRequest;
@@ -33,5 +34,12 @@ public class ExternalOrderController {
     public ResponseEntity<OrderDetailResponse> updateStatus(@PathVariable UUID id,
                                                             @Valid @RequestBody OrderStatusRequest request) {
         return ResponseEntity.ok(orderService.updateStatus(id, request));
+    }
+
+    @Operation(summary = "Reportar última posición conocida del pedido desde sistema externo")
+    @PatchMapping("/{id}/location")
+    public ResponseEntity<OrderDetailResponse> updateLocation(@PathVariable UUID id,
+                                                              @Valid @RequestBody OrderLocationRequest request) {
+        return ResponseEntity.ok(orderService.updateLocation(id, request));
     }
 }

--- a/backend/src/main/java/com/delivera/dto/order/OrderDetailResponse.java
+++ b/backend/src/main/java/com/delivera/dto/order/OrderDetailResponse.java
@@ -32,7 +32,10 @@ public record OrderDetailResponse(
         Double originLat,
         Double originLon,
         Double destinationLat,
-        Double destinationLon) {
+        Double destinationLon,
+        Double currentLat,
+        Double currentLon,
+        Instant currentLocationAt) {
 
     public static OrderDetailResponse from(Order order) {
         var lu = order.getLoyalUser();
@@ -69,6 +72,9 @@ public record OrderDetailResponse(
                 order.getOrigin().getLatitude() != null ? order.getOrigin().getLatitude().doubleValue() : null,
                 order.getOrigin().getLongitude() != null ? order.getOrigin().getLongitude().doubleValue() : null,
                 destLat,
-                destLon);
+                destLon,
+                order.getCurrentLat() != null ? order.getCurrentLat().doubleValue() : null,
+                order.getCurrentLon() != null ? order.getCurrentLon().doubleValue() : null,
+                order.getCurrentLocationAt());
     }
 }

--- a/backend/src/main/java/com/delivera/dto/order/OrderLocationRequest.java
+++ b/backend/src/main/java/com/delivera/dto/order/OrderLocationRequest.java
@@ -1,0 +1,11 @@
+package com.delivera.dto.order;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record OrderLocationRequest(
+        @NotNull @DecimalMin(value = "-90.0") @DecimalMax(value = "90.0") BigDecimal lat,
+        @NotNull @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0") BigDecimal lon) {}

--- a/backend/src/main/java/com/delivera/dto/order/OrderResponse.java
+++ b/backend/src/main/java/com/delivera/dto/order/OrderResponse.java
@@ -28,7 +28,10 @@ public record OrderResponse(
         Double originLat,
         Double originLon,
         Double destinationLat,
-        Double destinationLon) {
+        Double destinationLon,
+        Double currentLat,
+        Double currentLon,
+        Instant currentLocationAt) {
 
     public static OrderResponse from(Order order) {
         var lu = order.getLoyalUser();
@@ -62,6 +65,9 @@ public record OrderResponse(
                 order.getOrigin().getLatitude() != null ? order.getOrigin().getLatitude().doubleValue() : null,
                 order.getOrigin().getLongitude() != null ? order.getOrigin().getLongitude().doubleValue() : null,
                 destLat,
-                destLon);
+                destLon,
+                order.getCurrentLat() != null ? order.getCurrentLat().doubleValue() : null,
+                order.getCurrentLon() != null ? order.getCurrentLon().doubleValue() : null,
+                order.getCurrentLocationAt());
     }
 }

--- a/backend/src/main/java/com/delivera/model/Order.java
+++ b/backend/src/main/java/com/delivera/model/Order.java
@@ -69,6 +69,15 @@ public class Order {
     @Column(name = "recipient_longitude", precision = 9, scale = 6)
     private java.math.BigDecimal recipientLongitude;
 
+    @Column(name = "current_lat", precision = 9, scale = 6)
+    private java.math.BigDecimal currentLat;
+
+    @Column(name = "current_lon", precision = 9, scale = 6)
+    private java.math.BigDecimal currentLon;
+
+    @Column(name = "current_location_at")
+    private Instant currentLocationAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "loyal_user_id")
     private LoyalUser loyalUser;

--- a/backend/src/main/java/com/delivera/service/OrderService.java
+++ b/backend/src/main/java/com/delivera/service/OrderService.java
@@ -160,6 +160,17 @@ public class OrderService {
     }
 
     @Transactional
+    public OrderDetailResponse updateLocation(UUID id, OrderLocationRequest request) {
+        UUID companyId = securityUtils.getCurrentCompanyId();
+        Order order = orderRepository.findByIdAndCompanyId(id, companyId)
+                .orElseThrow(OrderNotFoundException::new);
+        order.setCurrentLat(request.lat());
+        order.setCurrentLon(request.lon());
+        order.setCurrentLocationAt(java.time.Instant.now());
+        return OrderDetailResponse.from(orderRepository.save(order));
+    }
+
+    @Transactional
     public void delete(UUID id) {
         UUID companyId = securityUtils.getCurrentCompanyId();
         Order order = orderRepository.findByIdAndCompanyId(id, companyId)

--- a/backend/src/main/resources/db/migration/V42__order_current_location.sql
+++ b/backend/src/main/resources/db/migration/V42__order_current_location.sql
@@ -1,0 +1,4 @@
+ALTER TABLE orders
+    ADD COLUMN current_lat NUMERIC(9, 6),
+    ADD COLUMN current_lon NUMERIC(9, 6),
+    ADD COLUMN current_location_at TIMESTAMP;

--- a/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
+++ b/backend/src/test/java/com/delivera/controller/ExternalOrderControllerTest.java
@@ -1,9 +1,11 @@
 package com.delivera.controller;
 
 import com.delivera.dto.order.OrderDetailResponse;
+import com.delivera.dto.order.OrderLocationRequest;
 import com.delivera.dto.order.OrderRequest;
 import com.delivera.dto.order.OrderResponse;
 import com.delivera.dto.order.OrderStatusRequest;
+import java.math.BigDecimal;
 import com.delivera.model.OrderStatus;
 import com.delivera.model.OrderType;
 import com.delivera.service.OrderService;
@@ -30,7 +32,7 @@ class ExternalOrderControllerTest {
         OrderRequest req = new OrderRequest(UUID.randomUUID(), null, "a@b.com", "John",
                 "calle", null, null, OrderType.B2C, null, null);
         OrderResponse expected = new OrderResponse(UUID.randomUUID(), null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, null, null, null, null);
         when(orderService.create(req)).thenReturn(expected);
 
         var resp = controller.create(req);
@@ -46,7 +48,7 @@ class ExternalOrderControllerTest {
         OrderStatusRequest req = new OrderStatusRequest(OrderStatus.IN_TRANSIT, "actualizado por ERP");
         OrderDetailResponse expected = new OrderDetailResponse(id, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, "IN_TRANSIT", null, null, false, null, null,
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
         when(orderService.updateStatus(id, req)).thenReturn(expected);
 
         var resp = controller.updateStatus(id, req);
@@ -54,5 +56,21 @@ class ExternalOrderControllerTest {
         assertThat(resp.getStatusCode().value()).isEqualTo(200);
         assertThat(resp.getBody()).isSameAs(expected);
         verify(orderService).updateStatus(id, req);
+    }
+
+    @Test
+    void delegatesLocationUpdateToOrderService() {
+        UUID id = UUID.randomUUID();
+        OrderLocationRequest req = new OrderLocationRequest(new BigDecimal("40.4168"), new BigDecimal("-3.7038"));
+        OrderDetailResponse expected = new OrderDetailResponse(id, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, false, null, null,
+                null, null, null, null, null, null, null, null, null);
+        when(orderService.updateLocation(id, req)).thenReturn(expected);
+
+        var resp = controller.updateLocation(id, req);
+
+        assertThat(resp.getStatusCode().value()).isEqualTo(200);
+        assertThat(resp.getBody()).isSameAs(expected);
+        verify(orderService).updateLocation(id, req);
     }
 }

--- a/backend/src/test/java/com/delivera/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/OrderServiceTest.java
@@ -4,6 +4,7 @@ import com.delivera.security.SecurityUtils;
 import com.delivera.dto.order.OrderRequest;
 import com.delivera.model.OrderType;
 import com.delivera.dto.order.OrderStatusRequest;
+import com.delivera.dto.order.OrderLocationRequest;
 import com.delivera.exception.InvalidOrderUnitsException;
 import com.delivera.exception.OrderNotFoundException;
 import com.delivera.model.*;
@@ -150,6 +151,30 @@ class OrderServiceTest {
         when(orderRepository.save(order)).thenReturn(order);
 
         assertThat(orderService.updateStatus(order.getId(), req)).isNotNull();
+    }
+
+    @Test
+    void updateLocation_setsCoordinatesAndTimestamp() {
+        OrderLocationRequest req = new OrderLocationRequest(new java.math.BigDecimal("40.4"), new java.math.BigDecimal("-3.7"));
+        when(securityUtils.getCurrentCompanyId()).thenReturn(companyId);
+        when(orderRepository.findByIdAndCompanyId(order.getId(), companyId)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+
+        orderService.updateLocation(order.getId(), req);
+
+        assertThat(order.getCurrentLat()).isEqualByComparingTo("40.4");
+        assertThat(order.getCurrentLon()).isEqualByComparingTo("-3.7");
+        assertThat(order.getCurrentLocationAt()).isNotNull();
+    }
+
+    @Test
+    void updateLocation_orderNotFoundThrows() {
+        OrderLocationRequest req = new OrderLocationRequest(new java.math.BigDecimal("40"), new java.math.BigDecimal("-3"));
+        when(securityUtils.getCurrentCompanyId()).thenReturn(companyId);
+        when(orderRepository.findByIdAndCompanyId(any(), any())).thenReturn(Optional.empty());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> orderService.updateLocation(order.getId(), req))
+                .isInstanceOf(com.delivera.exception.OrderNotFoundException.class);
     }
 
     @Test

--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -1,5 +1,20 @@
-import { describe, it, expect } from 'vitest'
-import { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf } from '@/composables/useDeliveraMap'
+import { describe, it, expect, vi } from 'vitest'
+
+const addToMock = vi.fn()
+const bindPopupMock = vi.fn()
+const circleMarkerMock = vi.fn(() => ({ addTo: addToMock, bindPopup: bindPopupMock }))
+addToMock.mockImplementation(() => ({ addTo: addToMock, bindPopup: bindPopupMock }))
+
+vi.mock('leaflet', () => ({
+  default: {
+    Icon: { Default: { prototype: {}, mergeOptions: vi.fn() } },
+    circleMarker: circleMarkerMock,
+  },
+}))
+vi.mock('leaflet.markercluster', () => ({}))
+
+const { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf, addCurrentLocationMarker } =
+  await import('@/composables/useDeliveraMap')
 
 describe('routeColorFor', () => {
   it('mapea cada estado conocido a su color', () => {
@@ -28,5 +43,29 @@ describe('currentLocationOf', () => {
     expect(currentLocationOf({ currentLat: 1 })).toBeNull()
     expect(currentLocationOf({ currentLon: 1 })).toBeNull()
     expect(currentLocationOf({ currentLat: null, currentLon: 1 })).toBeNull()
+  })
+})
+
+describe('addCurrentLocationMarker', () => {
+  it('devuelve null si falta map, location, lat o lon', () => {
+    expect(addCurrentLocationMarker(null, { lat: 1, lon: 2 }, '#000')).toBeNull()
+    expect(addCurrentLocationMarker({}, null, '#000')).toBeNull()
+    expect(addCurrentLocationMarker({}, { lat: null, lon: 2 }, '#000')).toBeNull()
+    expect(addCurrentLocationMarker({}, { lat: 1, lon: null }, '#000')).toBeNull()
+  })
+
+  it('crea circleMarker con el color y vincula popup cuando hay título', () => {
+    circleMarkerMock.mockClear()
+    bindPopupMock.mockClear()
+    const marker = addCurrentLocationMarker({}, { lat: 40, lon: -3 }, '#abc', 'ref-1', 'sub')
+    expect(circleMarkerMock).toHaveBeenCalledWith([40, -3], expect.objectContaining({ fillColor: '#abc' }))
+    expect(bindPopupMock).toHaveBeenCalled()
+    expect(marker).not.toBeNull()
+  })
+
+  it('no vincula popup si no hay título', () => {
+    bindPopupMock.mockClear()
+    addCurrentLocationMarker({}, { lat: 1, lon: 2 }, '#000', null, null)
+    expect(bindPopupMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -83,7 +83,7 @@ describe('addCurrentLocationMarker', () => {
 describe('addRoute', () => {
   it('crea polilínea discontinua con color del estado cuando OSRM falla', async () => {
     polylineMock.mockClear()
-    global.fetch = vi.fn().mockRejectedValue(new Error('osrm down'))
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('osrm down'))
     const map = {}
     const entry = await addRoute(map, {
       orderId: 'o1',

--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -2,18 +2,28 @@ import { describe, it, expect, vi } from 'vitest'
 
 const addToMock = vi.fn()
 const bindPopupMock = vi.fn()
+const closePopupMock = vi.fn()
+const onMock = vi.fn()
+const bringToFrontMock = vi.fn()
 const circleMarkerMock = vi.fn(() => ({ addTo: addToMock, bindPopup: bindPopupMock }))
-addToMock.mockImplementation(() => ({ addTo: addToMock, bindPopup: bindPopupMock }))
+const polylineMock = vi.fn(() => ({
+  addTo: addToMock, bindPopup: bindPopupMock, on: onMock, closePopup: closePopupMock, bringToFront: bringToFrontMock,
+}))
+addToMock.mockImplementation(() => ({
+  addTo: addToMock, bindPopup: bindPopupMock, on: onMock, closePopup: closePopupMock, bringToFront: bringToFrontMock,
+}))
 
 vi.mock('leaflet', () => ({
   default: {
     Icon: { Default: { prototype: {}, mergeOptions: vi.fn() } },
     circleMarker: circleMarkerMock,
+    polyline: polylineMock,
+    DomEvent: { stopPropagation: vi.fn() },
   },
 }))
 vi.mock('leaflet.markercluster', () => ({}))
 
-const { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf, addCurrentLocationMarker } =
+const { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf, addCurrentLocationMarker, addRoute } =
   await import('@/composables/useDeliveraMap')
 
 describe('routeColorFor', () => {
@@ -67,5 +77,24 @@ describe('addCurrentLocationMarker', () => {
     bindPopupMock.mockClear()
     addCurrentLocationMarker({}, { lat: 1, lon: 2 }, '#000', null, null)
     expect(bindPopupMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('addRoute', () => {
+  it('crea polilínea discontinua con color del estado cuando OSRM falla', async () => {
+    polylineMock.mockClear()
+    global.fetch = vi.fn().mockRejectedValue(new Error('osrm down'))
+    const map = {}
+    const entry = await addRoute(map, {
+      orderId: 'o1',
+      origin: { lat: 1, lon: 2 },
+      dest: { lat: 3, lon: 4 },
+      popupTitle: 'r-1', popupSubtitle: 'sub', actionLabel: null, router: null,
+      status: 'IN_TRANSIT',
+    })
+    expect(polylineMock).toHaveBeenCalled()
+    const optsArg = polylineMock.mock.calls[0][1]
+    expect(optsArg.color).toBe(ROUTE_STATUS_COLORS.IN_TRANSIT)
+    expect(entry.solid).toBe(false)
   })
 })

--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR } from '@/composables/useDeliveraMap'
+import { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf } from '@/composables/useDeliveraMap'
 
 describe('routeColorFor', () => {
   it('mapea cada estado conocido a su color', () => {
@@ -13,5 +13,20 @@ describe('routeColorFor', () => {
     expect(routeColorFor(null)).toBe(ROUTE_COLOR)
     expect(routeColorFor(undefined)).toBe(ROUTE_COLOR)
     expect(routeColorFor('FOO')).toBe(ROUTE_COLOR)
+  })
+})
+
+describe('currentLocationOf', () => {
+  it('parsea las coordenadas a número cuando ambas existen', () => {
+    expect(currentLocationOf({ currentLat: '40.4', currentLon: '-3.7' })).toEqual({ lat: 40.4, lon: -3.7 })
+    expect(currentLocationOf({ currentLat: 1, currentLon: 2 })).toEqual({ lat: 1, lon: 2 })
+  })
+
+  it('devuelve null cuando faltan coordenadas o el pedido es nulo', () => {
+    expect(currentLocationOf(null)).toBeNull()
+    expect(currentLocationOf({})).toBeNull()
+    expect(currentLocationOf({ currentLat: 1 })).toBeNull()
+    expect(currentLocationOf({ currentLon: 1 })).toBeNull()
+    expect(currentLocationOf({ currentLat: null, currentLon: 1 })).toBeNull()
   })
 })

--- a/frontend/src/composables/useDeliveraMap.js
+++ b/frontend/src/composables/useDeliveraMap.js
@@ -231,15 +231,19 @@ export async function addRoute(map, {
 
   if (map) { line.addTo(map); entry.layer = line }
 
-  if (map && currentLocation && currentLocation.lat != null && currentLocation.lon != null) {
-    const marker = L.circleMarker([currentLocation.lat, currentLocation.lon], {
-      radius: 7, color: '#fff', weight: 2, fillColor: color, fillOpacity: 1,
-    }).addTo(map)
-    if (popupTitle) marker.bindPopup(popupHtml({ title: popupTitle, subtitle: popupSubtitle, actionLabel: null }))
-    entry.currentMarker = marker
-  }
-
+  entry.currentMarker = addCurrentLocationMarker(map, currentLocation, color, popupTitle, popupSubtitle)
   return entry
+}
+
+// Crea un marcador circular con el color del estado sobre la ruta. Aislado para poder
+// testearlo sin instanciar el Map completo.
+export function addCurrentLocationMarker(map, currentLocation, color, popupTitle, popupSubtitle) {
+  if (!map || !currentLocation || currentLocation.lat == null || currentLocation.lon == null) return null
+  const marker = L.circleMarker([currentLocation.lat, currentLocation.lon], {
+    radius: 7, color: '#fff', weight: 2, fillColor: color, fillOpacity: 1,
+  }).addTo(map)
+  if (popupTitle) marker.bindPopup(popupHtml({ title: popupTitle, subtitle: popupSubtitle, actionLabel: null }))
+  return marker
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/composables/useDeliveraMap.js
+++ b/frontend/src/composables/useDeliveraMap.js
@@ -36,6 +36,13 @@ export function routeColorFor(status) {
   return ROUTE_STATUS_COLORS[status] || ROUTE_COLOR
 }
 
+// Devuelve { lat, lon } parseado a partir de los campos currentLat/currentLon del pedido,
+// o null si alguno es nulo. Centralizado para reutilizar en todas las vistas y testear.
+export function currentLocationOf(order) {
+  if (!order || order.currentLat == null || order.currentLon == null) return null
+  return { lat: parseFloat(order.currentLat), lon: parseFloat(order.currentLon) }
+}
+
 const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const TILE_ATTR = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 

--- a/frontend/src/composables/useDeliveraMap.js
+++ b/frontend/src/composables/useDeliveraMap.js
@@ -163,8 +163,9 @@ export function addMarker(map, {
 export async function addRoute(map, {
   orderId, origin, dest, popupTitle, popupSubtitle, actionLabel, router,
   timeoutMs = 6000, originMarker = null, destMarker = null, status = null,
+  currentLocation = null,
 }) {
-  const entry = { layer: null, solid: true, originMarker, destMarker }
+  const entry = { layer: null, solid: true, originMarker, destMarker, currentMarker: null }
   const color = routeColorFor(status)
 
   async function fetchOSRM() {
@@ -222,6 +223,15 @@ export async function addRoute(map, {
   }
 
   if (map) { line.addTo(map); entry.layer = line }
+
+  if (map && currentLocation && currentLocation.lat != null && currentLocation.lon != null) {
+    const marker = L.circleMarker([currentLocation.lat, currentLocation.lon], {
+      radius: 7, color: '#fff', weight: 2, fillColor: color, fillOpacity: 1,
+    }).addTo(map)
+    if (popupTitle) marker.bindPopup(popupHtml({ title: popupTitle, subtitle: popupSubtitle, actionLabel: null }))
+    entry.currentMarker = marker
+  }
+
   return entry
 }
 

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -202,6 +202,8 @@ async function initMap(unitList) {
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
       status: p.status,
+      currentLocation: p.currentLat != null && p.currentLon != null
+        ? { lat: parseFloat(p.currentLat), lon: parseFloat(p.currentLon) } : null,
     })
     routeEntries.push(entry)
     entry.layer?.bringToFront?.()

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -8,7 +8,7 @@ import Chart from 'primevue/chart'
 import L from 'leaflet'
 import {
   createMap, addMarker, addRoute, clusterOptions,
-  attachRouteVisibilityHandler,
+  attachRouteVisibilityHandler, currentLocationOf,
 } from '@/composables/useDeliveraMap'
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_COUNTRY } from '@/constants/map'
 
@@ -202,8 +202,7 @@ async function initMap(unitList) {
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
       status: p.status,
-      currentLocation: p.currentLat != null && p.currentLon != null
-        ? { lat: parseFloat(p.currentLat), lon: parseFloat(p.currentLon) } : null,
+      currentLocation: currentLocationOf(p),
     })
     routeEntries.push(entry)
     entry.layer?.bringToFront?.()

--- a/frontend/src/views/orders/MyOrderDetailView.vue
+++ b/frontend/src/views/orders/MyOrderDetailView.vue
@@ -69,6 +69,8 @@ async function initMap() {
     actionLabel: null,
     router,
     status: o.status,
+    currentLocation: o.currentLat != null && o.currentLon != null
+      ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
   })
   entry?.layer?.bringToFront?.()
 

--- a/frontend/src/views/orders/MyOrderDetailView.vue
+++ b/frontend/src/views/orders/MyOrderDetailView.vue
@@ -6,7 +6,7 @@ import { useAppConfig } from '@/composables/useAppConfig'
 import { fetchPublicOrder, useApi } from '@/composables/useApi'
 import { useFormatDate } from '@/composables/useFormatDate'
 import TimelineList from '@/components/TimelineList.vue'
-import { createMap, addMarker, addRoute, fitBounds } from '@/composables/useDeliveraMap'
+import { createMap, addMarker, addRoute, fitBounds, currentLocationOf } from '@/composables/useDeliveraMap'
 
 const { t } = useI18n()
 const { formatDateTime } = useFormatDate()
@@ -69,8 +69,7 @@ async function initMap() {
     actionLabel: null,
     router,
     status: o.status,
-    currentLocation: o.currentLat != null && o.currentLon != null
-      ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
+    currentLocation: currentLocationOf(o),
   })
   entry?.layer?.bringToFront?.()
 

--- a/frontend/src/views/orders/OrderDetailView.vue
+++ b/frontend/src/views/orders/OrderDetailView.vue
@@ -105,6 +105,8 @@ async function initOrderMap() {
       actionLabel: t('orders.viewDetail'),
       router,
       status: o.status,
+      currentLocation: o.currentLat != null && o.currentLon != null
+        ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
     })
     if (entry && !entry.solid) routeFailed.value = true
     entry?.layer?.bringToFront?.()

--- a/frontend/src/views/orders/OrderDetailView.vue
+++ b/frontend/src/views/orders/OrderDetailView.vue
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useAppConfig } from '@/composables/useAppConfig'
 import { useFormatDate } from '@/composables/useFormatDate'
 import TimelineList from '@/components/TimelineList.vue'
-import { createMap, addMarker, addRoute, fitBounds } from '@/composables/useDeliveraMap'
+import { createMap, addMarker, addRoute, fitBounds, currentLocationOf } from '@/composables/useDeliveraMap'
 import { WORKER_ROLES } from '@/constants/roles'
 
 const { t } = useI18n()
@@ -105,8 +105,7 @@ async function initOrderMap() {
       actionLabel: t('orders.viewDetail'),
       router,
       status: o.status,
-      currentLocation: o.currentLat != null && o.currentLon != null
-        ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
+      currentLocation: currentLocationOf(o),
     })
     if (entry && !entry.solid) routeFailed.value = true
     entry?.layer?.bringToFront?.()

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -193,6 +193,8 @@ async function updateMapOrders() {
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
       status: o.status,
+      currentLocation: o.currentLat != null && o.currentLon != null
+        ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
     })
     if (token !== mapToken) { if (entry?.layer && map) map.removeLayer(entry.layer); return }
     routeEntries.push(entry)

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -11,7 +11,7 @@ import EmptyState from '@/components/EmptyState.vue'
 import L from 'leaflet'
 import {
   createMap, addMarker, addRoute, clusterOptions, fitBounds,
-  attachRouteVisibilityHandler,
+  attachRouteVisibilityHandler, currentLocationOf,
 } from '@/composables/useDeliveraMap'
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_REGION } from '@/constants/map'
 
@@ -193,8 +193,7 @@ async function updateMapOrders() {
       originMarker: markerByKey.get(originKey) || null,
       destMarker: markerByKey.get(destKey) || null,
       status: o.status,
-      currentLocation: o.currentLat != null && o.currentLon != null
-        ? { lat: parseFloat(o.currentLat), lon: parseFloat(o.currentLon) } : null,
+      currentLocation: currentLocationOf(o),
     })
     if (token !== mapToken) { if (entry?.layer && map) map.removeLayer(entry.layer); return }
     routeEntries.push(entry)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,6 @@ sonar.java.source=21
 sonar.java.binaries=backend/target/classes
 sonar.java.libraries=backend/target/dependency
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=**/config/**,**/dto/auth/**,**/dto/common/**,**/dto/settings/**,**/dto/config/**,**/dto/loyaluser/**,**/dto/unit/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
+sonar.coverage.exclusions=**/config/**,**/dto/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
 sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
Última posición conocida del pedido (reportada por sistemas externos) con marcador sobre la ruta.

Closes #192

## Cambios
**Backend**
- Migración V42: columnas `current_lat`, `current_lon`, `current_location_at` en `orders`
- `OrderLocationRequest` (lat/lon validados) y `OrderService.updateLocation`
- `PATCH /external/orders/{id}/location` (autenticado por API key)
- Coordenadas y timestamp expuestos en `OrderResponse` y `OrderDetailResponse`

**Frontend**
- `addRoute()` acepta `currentLocation` y dibuja un `circleMarker` con el color del estado sobre la ruta
- HomeView, OrdersView, OrderDetailView y MyOrderDetailView pasan la posición al mapa

**Tests**
- 2 tests de `OrderService.updateLocation` (set + not found)
- 1 test del nuevo método del controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Notas de la Versión

* **Nuevas Características**
  * Se agregó una nueva API para actualizar la ubicación actual de los pedidos (latitud y longitud)
  * Los detalles de los pedidos ahora muestran la ubicación actual del envío registrada con su marca de tiempo
  * Los mapas de seguimiento visualizan marcadores con la ubicación actual de cada pedido

<!-- end of auto-generated comment: release notes by coderabbit.ai -->