### PR TITLE
feat/orders-without-location-list

### DIFF
--- a/frontend/e2e/orders.spec.js
+++ b/frontend/e2e/orders.spec.js
@@ -10,6 +10,8 @@ const mockOrder = {
   destinationName: 'Oficina Madrid',
   recipientName: null,
   recipientEmail: null,
+  originLat: 40.4168,
+  originLon: -3.7038,
   createdAt: '2024-01-01T10:00:00Z',
 }
 

--- a/frontend/src/__tests__/useDeliveraMap.spec.js
+++ b/frontend/src/__tests__/useDeliveraMap.spec.js
@@ -23,8 +23,8 @@ vi.mock('leaflet', () => ({
 }))
 vi.mock('leaflet.markercluster', () => ({}))
 
-const { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf, addCurrentLocationMarker, addRoute } =
-  await import('@/composables/useDeliveraMap')
+const { routeColorFor, ROUTE_STATUS_COLORS, ROUTE_COLOR, currentLocationOf, addCurrentLocationMarker, addRoute,
+  isActiveOrder, hasOriginCoords } = await import('@/composables/useDeliveraMap')
 
 describe('routeColorFor', () => {
   it('mapea cada estado conocido a su color', () => {
@@ -77,6 +77,32 @@ describe('addCurrentLocationMarker', () => {
     bindPopupMock.mockClear()
     addCurrentLocationMarker({}, { lat: 1, lon: 2 }, '#000', null, null)
     expect(bindPopupMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('isActiveOrder', () => {
+  it('true para PENDING e IN_TRANSIT', () => {
+    expect(isActiveOrder({ status: 'PENDING' })).toBe(true)
+    expect(isActiveOrder({ status: 'IN_TRANSIT' })).toBe(true)
+  })
+  it('false para otros estados, null o undefined', () => {
+    expect(isActiveOrder({ status: 'DELIVERED' })).toBe(false)
+    expect(isActiveOrder({ status: 'CANCELLED' })).toBe(false)
+    expect(isActiveOrder(null)).toBe(false)
+    expect(isActiveOrder(undefined)).toBe(false)
+  })
+})
+
+describe('hasOriginCoords', () => {
+  it('true cuando ambas coordenadas están presentes', () => {
+    expect(hasOriginCoords({ originLat: 1, originLon: 2 })).toBe(true)
+    expect(hasOriginCoords({ originLat: 0, originLon: 0 })).toBe(true)
+  })
+  it('false si alguna falta o el pedido es nulo', () => {
+    expect(hasOriginCoords(null)).toBe(false)
+    expect(hasOriginCoords({})).toBe(false)
+    expect(hasOriginCoords({ originLat: 1 })).toBe(false)
+    expect(hasOriginCoords({ originLat: null, originLon: 1 })).toBe(false)
   })
 })
 

--- a/frontend/src/composables/useDeliveraMap.js
+++ b/frontend/src/composables/useDeliveraMap.js
@@ -43,6 +43,16 @@ export function currentLocationOf(order) {
   return { lat: parseFloat(order.currentLat), lon: parseFloat(order.currentLon) }
 }
 
+// True para pedidos en estado activo (PENDING o IN_TRANSIT).
+export function isActiveOrder(o) {
+  return !!o && (o.status === 'PENDING' || o.status === 'IN_TRANSIT')
+}
+
+// True si el pedido tiene coordenadas de origen utilizables para pintar el mapa.
+export function hasOriginCoords(o) {
+  return !!o && o.originLat != null && o.originLon != null
+}
+
 const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const TILE_ATTR = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -241,6 +241,7 @@ orders:
   deleteConfirm: Delete this order?
   viewDetail: View detail
   noMapOrders: No pending orders with coordinates
+  withoutCoordinates: Orders without location
   routeUnavailable: Route could not be calculated
   chat: Chat
   chatEmpty: No messages yet.

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -241,6 +241,7 @@ orders:
   deleteConfirm: "¿Eliminar este pedido?"
   viewDetail: Ver detalle
   noMapOrders: No hay pedidos pendientes con coordenadas
+  withoutCoordinates: Pedidos sin ubicación
   routeUnavailable: No se ha podido calcular la ruta
   chat: Chat
   chatEmpty: No hay mensajes todavía.

--- a/frontend/src/views/orders/OrdersView.css
+++ b/frontend/src/views/orders/OrdersView.css
@@ -86,3 +86,23 @@
 .filters-wrapper {
   padding: 0 20px 12px;
 }
+
+.orders-no-coords {
+  position: absolute; top: 12px; right: 12px;
+  background: rgba(255,255,255,0.95);
+  border: 1px solid var(--surface-border, #e5e7eb);
+  border-radius: 8px;
+  padding: 10px 12px;
+  max-width: 260px;
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.8rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,.12);
+}
+.orders-no-coords-title { font-weight: 600; margin: 0 0 6px; color: #b45309; }
+.orders-no-coords ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.orders-no-coords li { display: flex; flex-direction: column; }
+.orders-no-coords a { color: #7c3aed; font-weight: 500; text-decoration: none; }
+.orders-no-coords a:hover { text-decoration: underline; }
+.orders-no-coords-meta { color: #64748b; font-size: 0.7rem; }
+.orders-map-panel { position: relative; }

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -11,7 +11,7 @@ import EmptyState from '@/components/EmptyState.vue'
 import L from 'leaflet'
 import {
   createMap, addMarker, addRoute, clusterOptions, fitBounds,
-  attachRouteVisibilityHandler, currentLocationOf,
+  attachRouteVisibilityHandler, currentLocationOf, isActiveOrder, hasOriginCoords,
 } from '@/composables/useDeliveraMap'
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_REGION } from '@/constants/map'
 
@@ -67,12 +67,14 @@ const filtered = computed(() => {
   })
 })
 
-// Solo pedidos pendientes con coords origen (para el mapa)
+// Pedidos activos con coordenadas de origen (visibles en el mapa)
 const mappableOrders = computed(() =>
-  filtered.value.filter(o =>
-    (o.status === 'PENDING' || o.status === 'IN_TRANSIT') &&
-    o.originLat && o.originLon
-  )
+  filtered.value.filter(o => isActiveOrder(o) && hasOriginCoords(o))
+)
+
+// Pedidos activos SIN coordenadas (no aparecen en el mapa) — listado lateral DSI-22.3
+const unmappableOrders = computed(() =>
+  filtered.value.filter(o => isActiveOrder(o) && !hasOriginCoords(o))
 )
 
 function isOwnCompany(companyId) {
@@ -352,6 +354,16 @@ watch(orders, async () => {
           <span class="legend-item"><span class="legend-line legend-line--solid"></span>{{ t('map.legend.routeSolid') }}</span>
           <span class="legend-item"><span class="legend-line legend-line--dashed"></span>{{ t('map.legend.routeDashed') }}</span>
         </div>
+        <!-- Listado lateral de pedidos activos sin coordenadas (DSI-22.3) -->
+        <aside v-if="unmappableOrders.length > 0" class="orders-no-coords">
+          <p class="orders-no-coords-title">{{ t('orders.withoutCoordinates') }} ({{ unmappableOrders.length }})</p>
+          <ul>
+            <li v-for="o in unmappableOrders" :key="o.id">
+              <a href="#" @click.prevent="router.push(`/orders/${o.id}`)">{{ o.reference }}</a>
+              <span class="orders-no-coords-meta">{{ o.originName }} → {{ o.destinationName || o.recipientName || o.recipientEmail || '—' }}</span>
+            </li>
+          </ul>
+        </aside>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Listado lateral de pedidos activos que no aparecen en el mapa por falta de coordenadas.

Closes #193

## Cambios
- `useDeliveraMap`: nuevos helpers `isActiveOrder()` y `hasOriginCoords()` reutilizables
- `OrdersView`: nuevo computed `unmappableOrders` y panel `<aside>` con enlaces a la ficha del pedido, posicionado sobre el mapa
- Traducciones (`orders.withoutCoordinates`)
- Tests unitarios de los helpers