### PR TITLE
feat/company-default-priority

### DIFF
--- a/backend/src/main/java/com/delivera/dto/settings/CompanyUpdateRequest.java
+++ b/backend/src/main/java/com/delivera/dto/settings/CompanyUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.delivera.dto.settings;
 
+import com.delivera.model.OrderPriority;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -8,5 +9,7 @@ public record CompanyUpdateRequest(
         String name,
 
         @NotBlank @Size(max = 50)
-        String activityType
+        String activityType,
+
+        OrderPriority defaultPriority
 ) {}

--- a/backend/src/main/java/com/delivera/dto/settings/SettingsResponse.java
+++ b/backend/src/main/java/com/delivera/dto/settings/SettingsResponse.java
@@ -1,5 +1,7 @@
 package com.delivera.dto.settings;
 
+import com.delivera.model.OrderPriority;
+
 import java.util.UUID;
 
 public record SettingsResponse(
@@ -8,5 +10,6 @@ public record SettingsResponse(
         String orgHandle,
         UUID companyId,
         String companyName,
-        String activityType
+        String activityType,
+        OrderPriority defaultPriority
 ) {}

--- a/backend/src/main/java/com/delivera/model/Company.java
+++ b/backend/src/main/java/com/delivera/model/Company.java
@@ -38,6 +38,10 @@ public class Company {
     @Column(name = "logo_data", columnDefinition = "TEXT")
     private String logoData;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "default_priority", length = 10)
+    private OrderPriority defaultPriority;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Instant createdAt;
 }

--- a/backend/src/main/java/com/delivera/service/OrderService.java
+++ b/backend/src/main/java/com/delivera/service/OrderService.java
@@ -100,7 +100,7 @@ public class OrderService {
         order.setOrigin(origin);
         order.setDestination(destination);
         order.setStatus(OrderStatus.PENDING);
-        order.setPriority(request.priority() != null ? request.priority() : OrderPriority.NORMAL);
+        order.setPriority(resolveDefaultPriority(request.priority(), company));
         order.setNotes(request.notes() != null ? request.notes().trim() : null);
 
         if (orderType == OrderType.B2C && request.recipientEmail() != null) {
@@ -223,6 +223,14 @@ public class OrderService {
         order.setRecipientAddress(addr);
         order.setRecipientLatitude(lat);
         order.setRecipientLongitude(lon);
+    }
+
+    // Resuelve la prioridad efectiva: petición > config empresa > NORMAL.
+    // Centralizado para soportar herencia de configuración (DSI-23.1).
+    static OrderPriority resolveDefaultPriority(OrderPriority requested, com.delivera.model.Company company) {
+        if (requested != null) return requested;
+        if (company != null && company.getDefaultPriority() != null) return company.getDefaultPriority();
+        return OrderPriority.NORMAL;
     }
 
     private String generateReference() {

--- a/backend/src/main/java/com/delivera/service/SettingsService.java
+++ b/backend/src/main/java/com/delivera/service/SettingsService.java
@@ -54,7 +54,7 @@ public class SettingsService {
     public SettingsResponse getSettings() {
         Company c = currentCompany();
         Organization o = c.getOrganization();
-        return new SettingsResponse(o.getId(), o.getName(), o.getHandle(), c.getId(), c.getName(), c.getActivityType().getCode());
+        return new SettingsResponse(o.getId(), o.getName(), o.getHandle(), c.getId(), c.getName(), c.getActivityType().getCode(), c.getDefaultPriority());
     }
 
     @Transactional
@@ -75,6 +75,7 @@ public class SettingsService {
         Company c = currentCompany();
         c.setName(req.name());
         c.setActivityType(activityTypeRepository.getReferenceById(req.activityType()));
+        c.setDefaultPriority(req.defaultPriority());
         companyRepository.save(c);
         return getSettings();
     }

--- a/backend/src/main/resources/db/migration/V43__company_default_priority.sql
+++ b/backend/src/main/resources/db/migration/V43__company_default_priority.sql
@@ -1,0 +1,2 @@
+ALTER TABLE companies
+    ADD COLUMN default_priority VARCHAR(10);

--- a/backend/src/test/java/com/delivera/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/OrderServiceTest.java
@@ -101,6 +101,17 @@ class OrderServiceTest {
     }
 
     @Test
+    void resolveDefaultPriority_prefersRequestedThenCompanyThenNormal() {
+        Company c = new Company();
+        assertThat(OrderService.resolveDefaultPriority(OrderPriority.HIGH, c)).isEqualTo(OrderPriority.HIGH);
+        assertThat(OrderService.resolveDefaultPriority(null, null)).isEqualTo(OrderPriority.NORMAL);
+        c.setDefaultPriority(OrderPriority.LOW);
+        assertThat(OrderService.resolveDefaultPriority(null, c)).isEqualTo(OrderPriority.LOW);
+        c.setDefaultPriority(null);
+        assertThat(OrderService.resolveDefaultPriority(null, c)).isEqualTo(OrderPriority.NORMAL);
+    }
+
+    @Test
     void getByCompany_returnsMappedList() {
         when(securityUtils.getCurrentCompanyId()).thenReturn(companyId);
         when(orderRepository.findSentOrReceivedByCompanyId(companyId)).thenReturn(List.of(order));

--- a/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
@@ -145,7 +145,7 @@ class SettingsServiceTest {
 
     @Test
     void updateCompany_success() {
-        CompanyUpdateRequest req = new CompanyUpdateRequest("Renamed", "FOOD");
+        CompanyUpdateRequest req = new CompanyUpdateRequest("Renamed", "FOOD", null);
         ActivityType food = new ActivityType(); food.setCode("FOOD");
         when(activityTypeRepository.getReferenceById("FOOD")).thenReturn(food);
         when(companyRepository.save(company)).thenReturn(company);

--- a/frontend/src/__tests__/useOrderPriority.spec.js
+++ b/frontend/src/__tests__/useOrderPriority.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { ORDER_PRIORITIES, buildPriorityOptions, resolveOrderPriority } from '@/composables/useOrderPriority'
+
+describe('buildPriorityOptions', () => {
+  it('genera 3 opciones HIGH/NORMAL/LOW con label traducido', () => {
+    const t = key => `T(${key})`
+    expect(buildPriorityOptions(t)).toEqual([
+      { value: 'HIGH', label: 'T(orders.priority.HIGH)' },
+      { value: 'NORMAL', label: 'T(orders.priority.NORMAL)' },
+      { value: 'LOW', label: 'T(orders.priority.LOW)' },
+    ])
+  })
+})
+
+describe('resolveOrderPriority', () => {
+  it('prefiere la solicitada sobre cualquier default', () => {
+    expect(resolveOrderPriority('HIGH', 'LOW')).toBe('HIGH')
+  })
+  it('cae en el default de empresa cuando no hay solicitada', () => {
+    expect(resolveOrderPriority(null, 'LOW')).toBe('LOW')
+    expect(resolveOrderPriority(undefined, 'HIGH')).toBe('HIGH')
+  })
+  it('NORMAL como fallback final', () => {
+    expect(resolveOrderPriority(null, null)).toBe('NORMAL')
+    expect(resolveOrderPriority('', '')).toBe('NORMAL')
+  })
+})
+
+describe('ORDER_PRIORITIES', () => {
+  it('expone las 3 prioridades válidas', () => {
+    expect(ORDER_PRIORITIES).toEqual(['HIGH', 'NORMAL', 'LOW'])
+  })
+})

--- a/frontend/src/composables/useOrderPriority.js
+++ b/frontend/src/composables/useOrderPriority.js
@@ -1,0 +1,16 @@
+// Helpers reutilizables para gestionar la prioridad efectiva de un pedido,
+// con herencia desde la configuración de empresa (DSI-23.1).
+
+export const ORDER_PRIORITIES = ['HIGH', 'NORMAL', 'LOW']
+
+// Construye las opciones para un selector de prioridad a partir de la función de traducción.
+export function buildPriorityOptions(t) {
+  return ORDER_PRIORITIES.map(value => ({ value, label: t(`orders.priority.${value}`) }))
+}
+
+// Resuelve la prioridad efectiva: solicitada > config empresa > NORMAL.
+export function resolveOrderPriority(requested, companyDefault) {
+  if (requested) return requested
+  if (companyDefault) return companyDefault
+  return 'NORMAL'
+}

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -443,6 +443,8 @@ settings:
   companySection: Company
   subscriptionSection: Plan
   apiKeysSection: API keys
+  defaultPriority: Default priority
+  defaultPriorityHelp: Applied to new orders when no priority is specified
   currentPlan: Current plan
   availablePlans: Available plans
   selectPlan: Switch to this plan

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -443,6 +443,8 @@ settings:
   companySection: Empresa
   subscriptionSection: Plan
   apiKeysSection: API keys
+  defaultPriority: Prioridad por defecto
+  defaultPriorityHelp: Se aplica al crear pedidos cuando no se indica una prioridad
   currentPlan: Plan actual
   availablePlans: Planes disponibles
   selectPlan: Cambiar a este plan

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -6,6 +6,7 @@ import { useApi } from '@/composables/useApi'
 import { useAuthStore } from '@/stores/auth'
 import { useValidation } from '@/composables/useValidation'
 import { useActivityTypes } from '@/composables/useActivityTypes'
+import { buildPriorityOptions } from '@/composables/useOrderPriority'
 import { useAppConfig } from '@/composables/useAppConfig'
 import DeleteConfirmPanel from '@/components/DeleteConfirmPanel.vue'
 import ApiKeysSection from './ApiKeysSection.vue'
@@ -65,11 +66,7 @@ const companyTypeOptions = computed(() => [
   ...activityTypes.value.map(a => ({ label: a.label, value: a.value }))
 ])
 
-const defaultPriorityOptions = computed(() => [
-  { label: t('orders.priority.HIGH'), value: 'HIGH' },
-  { label: t('orders.priority.NORMAL'), value: 'NORMAL' },
-  { label: t('orders.priority.LOW'), value: 'LOW' },
-])
+const defaultPriorityOptions = computed(() => buildPriorityOptions(t))
 
 // Logo crop (igual que avatar en perfil)
 const LOGO_CANVAS_SIZE = 280

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -36,6 +36,7 @@ const orgSuccess = ref(false)
 const editingCompanyId = ref(null)
 const companyName = ref('')
 const activityType = ref(null)
+const defaultPriority = ref(null)
 const companySaving = ref(false)
 const companyError = ref('')
 const companySuccess = ref(false)
@@ -62,6 +63,12 @@ watch([companySearch, companyTypeFilter], () => { companyPage.value = 1 })
 const companyTypeOptions = computed(() => [
   { label: t('settings.filterAll'), value: 'ALL' },
   ...activityTypes.value.map(a => ({ label: a.label, value: a.value }))
+])
+
+const defaultPriorityOptions = computed(() => [
+  { label: t('orders.priority.HIGH'), value: 'HIGH' },
+  { label: t('orders.priority.NORMAL'), value: 'NORMAL' },
+  { label: t('orders.priority.LOW'), value: 'LOW' },
 ])
 
 // Logo crop (igual que avatar en perfil)
@@ -322,6 +329,7 @@ function startEditCompany(company) {
   editingCompanyId.value = company.id
   companyName.value = company.name
   activityType.value = company.activityType
+  defaultPriority.value = company.defaultPriority || null
   companyError.value = ''
   companySuccess.value = false
 }
@@ -337,7 +345,7 @@ async function saveCompany() {
   companySaving.value = true
   companyError.value = ''
   try {
-    const res = await api.put('/settings/company', { name: companyName.value, activityType: activityType.value })
+    const res = await api.put('/settings/company', { name: companyName.value, activityType: activityType.value, defaultPriority: defaultPriority.value })
     if (res.ok) {
       const updated = await res.json()
       settings.value = updated
@@ -567,6 +575,11 @@ async function copyHandle() {
                       <div class="form-field">
                         <label>{{ t('fields.type') }}</label>
                         <PSelect v-model="activityType" :options="activityOptions" option-label="label" option-value="value" fluid />
+                      </div>
+                      <div class="form-field">
+                        <label>{{ t('settings.defaultPriority') }}</label>
+                        <PSelect v-model="defaultPriority" :options="defaultPriorityOptions" option-label="label" option-value="value" fluid show-clear />
+                        <small class="field-help">{{ t('settings.defaultPriorityHelp') }}</small>
                       </div>
                       <PMessage v-if="companyError" severity="error" :closable="false" class="form-message">{{ companyError }}</PMessage>
                       <div class="form-actions">


### PR DESCRIPTION
Prioridad por defecto configurable a nivel de empresa, con herencia automática al crear pedidos.

Closes #194

## Cambios
**Backend**
- Migración V43: columna `default_priority` en `companies`
- Campo `defaultPriority` en `Company`, `CompanyUpdateRequest` y `SettingsResponse`
- `OrderService.resolveDefaultPriority(requested, company)`: petición > config empresa > NORMAL
- Test del helper

**Frontend**
- Selector "Prioridad por defecto" en el formulario de empresa (Configuración)
- Traducciones es/en