### PR TITLE
feat/unit-default-priority-override

### DIFF
--- a/backend/src/main/java/com/delivera/dto/unit/UnitRequest.java
+++ b/backend/src/main/java/com/delivera/dto/unit/UnitRequest.java
@@ -1,5 +1,6 @@
 package com.delivera.dto.unit;
 
+import com.delivera.model.OrderPriority;
 import com.delivera.model.UnitType;
 import jakarta.validation.constraints.*;
 
@@ -22,7 +23,9 @@ public record UnitRequest(
 
         @DecimalMin(value = "-180.0")
         @DecimalMax(value = "180.0")
-        BigDecimal longitude
+        BigDecimal longitude,
+
+        OrderPriority defaultPriority
 ) {
     @AssertTrue(message = "Latitude and longitude must both be provided or both be absent")
     public boolean isCoordinatesConsistent() {

--- a/backend/src/main/java/com/delivera/dto/unit/UnitResponse.java
+++ b/backend/src/main/java/com/delivera/dto/unit/UnitResponse.java
@@ -13,7 +13,8 @@ public record UnitResponse(
         String address,
         BigDecimal latitude,
         BigDecimal longitude,
-        Instant createdAt) {
+        Instant createdAt,
+        String defaultPriority) {
 
     public static UnitResponse from(OperationalUnit unit) {
         return new UnitResponse(
@@ -23,6 +24,7 @@ public record UnitResponse(
                 unit.getAddress(),
                 unit.getLatitude(),
                 unit.getLongitude(),
-                unit.getCreatedAt());
+                unit.getCreatedAt(),
+                unit.getDefaultPriority() != null ? unit.getDefaultPriority().name() : null);
     }
 }

--- a/backend/src/main/java/com/delivera/model/OperationalUnit.java
+++ b/backend/src/main/java/com/delivera/model/OperationalUnit.java
@@ -45,6 +45,10 @@ public class OperationalUnit {
     @Column(name = "created_at", insertable = false, updatable = false)
     private Instant createdAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "default_priority", length = 10)
+    private OrderPriority defaultPriority;
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "unit_workers",
             joinColumns = @JoinColumn(name = "unit_id"),

--- a/backend/src/main/java/com/delivera/service/OrderService.java
+++ b/backend/src/main/java/com/delivera/service/OrderService.java
@@ -100,7 +100,7 @@ public class OrderService {
         order.setOrigin(origin);
         order.setDestination(destination);
         order.setStatus(OrderStatus.PENDING);
-        order.setPriority(resolveDefaultPriority(request.priority(), company));
+        order.setPriority(resolveDefaultPriority(request.priority(), origin, company));
         order.setNotes(request.notes() != null ? request.notes().trim() : null);
 
         if (orderType == OrderType.B2C && request.recipientEmail() != null) {
@@ -225,10 +225,13 @@ public class OrderService {
         order.setRecipientLongitude(lon);
     }
 
-    // Resuelve la prioridad efectiva: petición > config empresa > NORMAL.
-    // Centralizado para soportar herencia de configuración (DSI-23.1).
-    static OrderPriority resolveDefaultPriority(OrderPriority requested, com.delivera.model.Company company) {
+    // Resuelve la prioridad efectiva: petición > unidad origen > empresa > NORMAL.
+    // Cadena de herencia con sobreescritura por unidad (DSI-23.1, DSI-23.2).
+    static OrderPriority resolveDefaultPriority(OrderPriority requested,
+                                                com.delivera.model.OperationalUnit originUnit,
+                                                com.delivera.model.Company company) {
         if (requested != null) return requested;
+        if (originUnit != null && originUnit.getDefaultPriority() != null) return originUnit.getDefaultPriority();
         if (company != null && company.getDefaultPriority() != null) return company.getDefaultPriority();
         return OrderPriority.NORMAL;
     }

--- a/backend/src/main/java/com/delivera/service/UnitService.java
+++ b/backend/src/main/java/com/delivera/service/UnitService.java
@@ -61,6 +61,7 @@ public class UnitService {
         unit.setAddress(request.address());
         unit.setLatitude(request.latitude());
         unit.setLongitude(request.longitude());
+        unit.setDefaultPriority(request.defaultPriority());
         try {
             return UnitResponse.from(unitRepository.save(unit));
         } catch (DataIntegrityViolationException e) {
@@ -81,6 +82,7 @@ public class UnitService {
         unit.setAddress(request.address());
         unit.setLatitude(request.latitude());
         unit.setLongitude(request.longitude());
+        unit.setDefaultPriority(request.defaultPriority());
         try {
             return UnitResponse.from(unitRepository.save(unit));
         } catch (DataIntegrityViolationException e) {

--- a/backend/src/main/java/com/delivera/service/UnitService.java
+++ b/backend/src/main/java/com/delivera/service/UnitService.java
@@ -56,12 +56,7 @@ public class UnitService {
                 .orElseThrow(CompanyContextException::new);
         var unit = new OperationalUnit();
         unit.setCompany(company);
-        unit.setName(request.name());
-        unit.setType(request.type());
-        unit.setAddress(request.address());
-        unit.setLatitude(request.latitude());
-        unit.setLongitude(request.longitude());
-        unit.setDefaultPriority(request.defaultPriority());
+        applyRequest(unit, request);
         try {
             return UnitResponse.from(unitRepository.save(unit));
         } catch (DataIntegrityViolationException e) {
@@ -77,12 +72,7 @@ public class UnitService {
         if (unitRepository.existsByCompanyIdAndNameAndIdNot(companyId, request.name(), unitId)) {
             throw new UnitNameConflictException();
         }
-        unit.setName(request.name());
-        unit.setType(request.type());
-        unit.setAddress(request.address());
-        unit.setLatitude(request.latitude());
-        unit.setLongitude(request.longitude());
-        unit.setDefaultPriority(request.defaultPriority());
+        applyRequest(unit, request);
         try {
             return UnitResponse.from(unitRepository.save(unit));
         } catch (DataIntegrityViolationException e) {
@@ -156,5 +146,14 @@ public class UnitService {
         var unit = unitRepository.findByIdAndCompanyId(id, companyId)
                 .orElseThrow(() -> new UnitNotFoundException(id));
         unitRepository.delete(unit);
+    }
+
+    private void applyRequest(OperationalUnit unit, UnitRequest request) {
+        unit.setName(request.name());
+        unit.setType(request.type());
+        unit.setAddress(request.address());
+        unit.setLatitude(request.latitude());
+        unit.setLongitude(request.longitude());
+        unit.setDefaultPriority(request.defaultPriority());
     }
 }

--- a/backend/src/main/resources/db/migration/V44__unit_default_priority.sql
+++ b/backend/src/main/resources/db/migration/V44__unit_default_priority.sql
@@ -1,0 +1,2 @@
+ALTER TABLE operational_units
+    ADD COLUMN default_priority VARCHAR(10);

--- a/backend/src/test/java/com/delivera/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/OrderServiceTest.java
@@ -101,14 +101,22 @@ class OrderServiceTest {
     }
 
     @Test
-    void resolveDefaultPriority_prefersRequestedThenCompanyThenNormal() {
+    void resolveDefaultPriority_followsRequestedUnitCompanyNormalChain() {
         Company c = new Company();
-        assertThat(OrderService.resolveDefaultPriority(OrderPriority.HIGH, c)).isEqualTo(OrderPriority.HIGH);
-        assertThat(OrderService.resolveDefaultPriority(null, null)).isEqualTo(OrderPriority.NORMAL);
+        OperationalUnit u = new OperationalUnit();
+        // Solicitada gana siempre
+        assertThat(OrderService.resolveDefaultPriority(OrderPriority.HIGH, u, c)).isEqualTo(OrderPriority.HIGH);
+        // Sin nada → NORMAL
+        assertThat(OrderService.resolveDefaultPriority(null, null, null)).isEqualTo(OrderPriority.NORMAL);
+        // Solo empresa
         c.setDefaultPriority(OrderPriority.LOW);
-        assertThat(OrderService.resolveDefaultPriority(null, c)).isEqualTo(OrderPriority.LOW);
-        c.setDefaultPriority(null);
-        assertThat(OrderService.resolveDefaultPriority(null, c)).isEqualTo(OrderPriority.NORMAL);
+        assertThat(OrderService.resolveDefaultPriority(null, null, c)).isEqualTo(OrderPriority.LOW);
+        // Unidad sobreescribe empresa
+        u.setDefaultPriority(OrderPriority.HIGH);
+        assertThat(OrderService.resolveDefaultPriority(null, u, c)).isEqualTo(OrderPriority.HIGH);
+        // Unidad sin valor → cae en empresa
+        u.setDefaultPriority(null);
+        assertThat(OrderService.resolveDefaultPriority(null, u, c)).isEqualTo(OrderPriority.LOW);
     }
 
     @Test

--- a/backend/src/test/java/com/delivera/service/UnitServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/UnitServiceTest.java
@@ -62,7 +62,7 @@ class UnitServiceTest {
         unit.setType(UnitType.WAREHOUSE);
         unit.setCompany(company);
 
-        request = new UnitRequest("Warehouse A", UnitType.WAREHOUSE, "1 Main St", null, null);
+        request = new UnitRequest("Warehouse A", UnitType.WAREHOUSE, "1 Main St", null, null, null);
     }
 
     @Test

--- a/frontend/src/__tests__/useUnitForm.spec.js
+++ b/frontend/src/__tests__/useUnitForm.spec.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key) => key }),
+}))
+
+const mockPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('@/composables/useValidation', () => ({
+  useValidation: () => ({
+    validate: vi.fn().mockReturnValue(true),
+    required: () => null,
+    errors: {},
+    invalids: {},
+  }),
+}))
+
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+vi.mock('@/composables/useApi', () => ({
+  useApi: () => ({
+    post: mockPost,
+    put: mockPut,
+    translateError: (_d, fallback) => fallback,
+  }),
+}))
+
+const { useUnitForm } = await import('@/composables/useUnitForm')
+
+beforeEach(() => {
+  mockPost.mockReset()
+  mockPut.mockReset()
+  mockPush.mockReset()
+})
+
+describe('useUnitForm submitUnit', () => {
+  it('envía defaultPriority cuando se indica', async () => {
+    mockPost.mockResolvedValue({ ok: true })
+    const f = useUnitForm()
+    f.name.value = 'U1'
+    f.unitType.value = 'WAREHOUSE'
+    f.address.value = 'calle'
+    f.defaultPriority.value = 'HIGH'
+
+    await f.submitUnit({ isEdit: false })
+
+    expect(mockPost).toHaveBeenCalledWith('/units', expect.objectContaining({
+      name: 'U1', defaultPriority: 'HIGH',
+    }))
+  })
+
+  it('envía defaultPriority null cuando se deja vacío', async () => {
+    mockPut.mockResolvedValue({ ok: true })
+    const f = useUnitForm()
+    f.name.value = 'U2'
+    f.unitType.value = 'STORE'
+    f.address.value = ''
+    f.defaultPriority.value = null
+
+    await f.submitUnit({ isEdit: true, unitId: 'abc' })
+
+    expect(mockPut).toHaveBeenCalledWith('/units/abc', expect.objectContaining({
+      defaultPriority: null,
+    }))
+  })
+})

--- a/frontend/src/composables/useUnitForm.js
+++ b/frontend/src/composables/useUnitForm.js
@@ -15,6 +15,7 @@ export function useUnitForm() {
   const address = ref('')
   const latitude = ref('')
   const longitude = ref('')
+  const defaultPriority = ref(null)
   const error = ref('')
   const success = ref('')
   const loading = ref(false)
@@ -64,6 +65,7 @@ export function useUnitForm() {
         address: address.value?.trim() || null,
         latitude: Number.isFinite(lat) ? lat : null,
         longitude: Number.isFinite(lon) ? lon : null,
+        defaultPriority: defaultPriority.value || null,
       }
       const res = isEdit
         ? await api.put(`/units/${unitId}`, body)
@@ -86,5 +88,5 @@ export function useUnitForm() {
     }
   }
 
-  return { name, unitType, address, latitude, longitude, error, success, loading, errors, invalids, submitUnit }
+  return { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit }
 }

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -165,6 +165,10 @@ units:
   new: New unit
   edit: Edit unit
   detail: Unit details
+  defaultPriority: Default priority (overrides company)
+  defaultPriorityHelp: If empty, the company default priority is used
+  priorityOverridden: Overridden
+  priorityInheritedFromCompany: Inherited from company
   created: Unit created successfully
   updated: Unit updated successfully
   empty: No operational units yet. Create the first one to start managing shipments.

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -165,6 +165,10 @@ units:
   new: Nueva unidad
   edit: Editar unidad
   detail: Detalles de la unidad
+  defaultPriority: Prioridad por defecto (sobreescribe la de la empresa)
+  defaultPriorityHelp: Si se deja vacío se usa la prioridad por defecto de la empresa
+  priorityOverridden: Sobreescrita
+  priorityInheritedFromCompany: Heredada de la empresa
   created: Unidad creada correctamente
   updated: Unidad actualizada correctamente
   empty: No hay unidades operativas. Crea la primera para poder gestionar envíos.

--- a/frontend/src/views/units/UnitDetailView.css
+++ b/frontend/src/views/units/UnitDetailView.css
@@ -92,3 +92,15 @@
   font-size: 14px;
   gap: 4px;
 }
+
+.priority-override-badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.5rem;
+  background: #fef3c7;
+  color: #b45309;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}

--- a/frontend/src/views/units/UnitDetailView.vue
+++ b/frontend/src/views/units/UnitDetailView.vue
@@ -122,6 +122,18 @@ onUnmounted(() => { if (map) { map.remove(); map = null } })
             <span class="info-label">{{ t('orders.date') }}</span>
             <span class="info-value">{{ formatDate(unit.createdAt) ?? '—' }}</span>
           </div>
+          <div class="info-item">
+            <span class="info-label">{{ t('settings.defaultPriority') }}</span>
+            <span class="info-value">
+              <template v-if="unit.defaultPriority">
+                {{ t('orders.priority.' + unit.defaultPriority) }}
+                <span class="priority-override-badge" :title="t('units.defaultPriority')">{{ t('units.priorityOverridden') }}</span>
+              </template>
+              <template v-else>
+                <em>{{ t('units.priorityInheritedFromCompany') }}</em>
+              </template>
+            </span>
+          </div>
         </div>
 
         <!-- Trabajadores asignados -->

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useApi } from '@/composables/useApi'
 import { useUnitForm } from '@/composables/useUnitForm'
+import { buildPriorityOptions } from '@/composables/useOrderPriority'
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_REGION } from '@/constants/map'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -22,7 +23,8 @@ const api = useApi()
 const unitId = computed(() => route.params.id || null)
 const isEdit = computed(() => !!unitId.value)
 
-const { name, unitType, address, latitude, longitude, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
+const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
+const priorityOptions = computed(() => buildPriorityOptions(t))
 const loadError = ref('')
 
 const mapEl = ref(null)
@@ -159,6 +161,7 @@ async function loadUnit(id) {
     address.value = unit.address || ''
     latitude.value = unit.latitude ?? ''
     longitude.value = unit.longitude ?? ''
+    defaultPriority.value = unit.defaultPriority || null
     if (ordersRes.ok) {
       const orders = await ordersRes.json()
       locationLocked.value = orders.some(o => o.originId === id || o.destinationId === id)
@@ -293,6 +296,12 @@ function handleSubmit() {
               fluid
             />
           </div>
+        </div>
+
+        <div class="form-field">
+          <label for="unit-default-priority">{{ t('units.defaultPriority') }}</label>
+          <PSelect id="unit-default-priority" v-model="defaultPriority" :options="priorityOptions" option-label="label" option-value="value" show-clear fluid />
+          <small class="field-hint">{{ t('units.defaultPriorityHelp') }}</small>
         </div>
 
         <PMessage v-if="error" severity="error" :closable="false" class="form-message">{{ error }}</PMessage>

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -24,7 +24,7 @@ const unitId = computed(() => route.params.id || null)
 const isEdit = computed(() => !!unitId.value)
 
 const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
-const priorityOptions = computed(() => buildPriorityOptions(t))
+const priorityOptions = buildPriorityOptions(t)
 const loadError = ref('')
 
 const mapEl = ref(null)


### PR DESCRIPTION
Sobreescritura de la prioridad por defecto a nivel de unidad operativa, con indicador visual en la ficha.

Closes #195

## Cambios
**Backend**
- Migración V44: columna `default_priority` en `operational_units`
- Campo `defaultPriority` en `OperationalUnit`, `UnitRequest` y `UnitResponse`
- `OrderService.resolveDefaultPriority(requested, originUnit, company)`: cadena petición > unidad > empresa > NORMAL
- Tests del helper actualizados

**Frontend**
- Selector "Prioridad por defecto" en `UnitFormView`
- Badge "Sobreescrita" o texto "Heredada de la empresa" en `UnitDetailView`
- Traducciones es/en

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nuevas Características
* Capacidad para establecer una prioridad predeterminada en unidades operacionales con herencia automática de la prioridad de la empresa cuando no se especifica.
* Interfaz actualizada para visualizar y gestionar prioridades unitarias con indicadores de si la prioridad es local o heredada de la empresa.

## Chores
* Actualizaciones de esquema de base de datos para soportar prioridades unitarias.
* Nuevas cadenas de traducción en inglés y español para la interfaz de prioridades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->