### PR TITLE
feat/company-config-lock

### DIFF
--- a/backend/src/main/java/com/delivera/dto/settings/CompanyUpdateRequest.java
+++ b/backend/src/main/java/com/delivera/dto/settings/CompanyUpdateRequest.java
@@ -11,5 +11,7 @@ public record CompanyUpdateRequest(
         @NotBlank @Size(max = 50)
         String activityType,
 
-        OrderPriority defaultPriority
+        OrderPriority defaultPriority,
+
+        boolean defaultPriorityLocked
 ) {}

--- a/backend/src/main/java/com/delivera/dto/settings/SettingsResponse.java
+++ b/backend/src/main/java/com/delivera/dto/settings/SettingsResponse.java
@@ -11,5 +11,6 @@ public record SettingsResponse(
         UUID companyId,
         String companyName,
         String activityType,
-        OrderPriority defaultPriority
+        OrderPriority defaultPriority,
+        boolean defaultPriorityLocked
 ) {}

--- a/backend/src/main/java/com/delivera/model/Company.java
+++ b/backend/src/main/java/com/delivera/model/Company.java
@@ -42,6 +42,9 @@ public class Company {
     @Column(name = "default_priority", length = 10)
     private OrderPriority defaultPriority;
 
+    @Column(name = "default_priority_locked", nullable = false)
+    private boolean defaultPriorityLocked = false;
+
     @Column(name = "created_at", insertable = false, updatable = false)
     private Instant createdAt;
 }

--- a/backend/src/main/java/com/delivera/service/OrderService.java
+++ b/backend/src/main/java/com/delivera/service/OrderService.java
@@ -227,11 +227,13 @@ public class OrderService {
 
     // Resuelve la prioridad efectiva: petición > unidad origen > empresa > NORMAL.
     // Cadena de herencia con sobreescritura por unidad (DSI-23.1, DSI-23.2).
+    // Si la empresa bloquea la configuración, ignora la sobreescritura de la unidad (DSI-23.3).
     static OrderPriority resolveDefaultPriority(OrderPriority requested,
                                                 com.delivera.model.OperationalUnit originUnit,
                                                 com.delivera.model.Company company) {
         if (requested != null) return requested;
-        if (originUnit != null && originUnit.getDefaultPriority() != null) return originUnit.getDefaultPriority();
+        boolean locked = company != null && company.isDefaultPriorityLocked();
+        if (!locked && originUnit != null && originUnit.getDefaultPriority() != null) return originUnit.getDefaultPriority();
         if (company != null && company.getDefaultPriority() != null) return company.getDefaultPriority();
         return OrderPriority.NORMAL;
     }

--- a/backend/src/main/java/com/delivera/service/SettingsService.java
+++ b/backend/src/main/java/com/delivera/service/SettingsService.java
@@ -54,7 +54,7 @@ public class SettingsService {
     public SettingsResponse getSettings() {
         Company c = currentCompany();
         Organization o = c.getOrganization();
-        return new SettingsResponse(o.getId(), o.getName(), o.getHandle(), c.getId(), c.getName(), c.getActivityType().getCode(), c.getDefaultPriority());
+        return new SettingsResponse(o.getId(), o.getName(), o.getHandle(), c.getId(), c.getName(), c.getActivityType().getCode(), c.getDefaultPriority(), c.isDefaultPriorityLocked());
     }
 
     @Transactional
@@ -76,6 +76,7 @@ public class SettingsService {
         c.setName(req.name());
         c.setActivityType(activityTypeRepository.getReferenceById(req.activityType()));
         c.setDefaultPriority(req.defaultPriority());
+        c.setDefaultPriorityLocked(req.defaultPriorityLocked());
         companyRepository.save(c);
         return getSettings();
     }

--- a/backend/src/main/resources/db/migration/V45__company_default_priority_locked.sql
+++ b/backend/src/main/resources/db/migration/V45__company_default_priority_locked.sql
@@ -1,0 +1,2 @@
+ALTER TABLE companies
+    ADD COLUMN default_priority_locked BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/test/java/com/delivera/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/OrderServiceTest.java
@@ -117,6 +117,10 @@ class OrderServiceTest {
         // Unidad sin valor → cae en empresa
         u.setDefaultPriority(null);
         assertThat(OrderService.resolveDefaultPriority(null, u, c)).isEqualTo(OrderPriority.LOW);
+        // Empresa bloquea: ignora sobreescritura de unidad
+        u.setDefaultPriority(OrderPriority.HIGH);
+        c.setDefaultPriorityLocked(true);
+        assertThat(OrderService.resolveDefaultPriority(null, u, c)).isEqualTo(OrderPriority.LOW);
     }
 
     @Test

--- a/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
@@ -145,7 +145,7 @@ class SettingsServiceTest {
 
     @Test
     void updateCompany_success() {
-        CompanyUpdateRequest req = new CompanyUpdateRequest("Renamed", "FOOD", null);
+        CompanyUpdateRequest req = new CompanyUpdateRequest("Renamed", "FOOD", null, false);
         ActivityType food = new ActivityType(); food.setCode("FOOD");
         when(activityTypeRepository.getReferenceById("FOOD")).thenReturn(food);
         when(companyRepository.save(company)).thenReturn(company);

--- a/frontend/src/__tests__/useCompanySettings.spec.js
+++ b/frontend/src/__tests__/useCompanySettings.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+vi.mock('@/composables/useApi', () => ({
+  useApi: () => ({ get: mockGet }),
+}))
+
+const { useCompanySettings, canUnitOverridePriority } = await import('@/composables/useCompanySettings')
+
+beforeEach(() => mockGet.mockReset())
+
+describe('useCompanySettings.load', () => {
+  it('guarda el body cuando la respuesta es ok', async () => {
+    mockGet.mockResolvedValue({ ok: true, json: async () => ({ defaultPriorityLocked: true }) })
+    const { settings, load } = useCompanySettings()
+    const result = await load()
+    expect(result).toEqual({ defaultPriorityLocked: true })
+    expect(settings.value).toEqual({ defaultPriorityLocked: true })
+  })
+
+  it('mantiene settings nulo cuando la respuesta no es ok', async () => {
+    mockGet.mockResolvedValue({ ok: false })
+    const { settings, load } = useCompanySettings()
+    const result = await load()
+    expect(result).toBeNull()
+    expect(settings.value).toBeNull()
+  })
+
+})
+
+describe('canUnitOverridePriority', () => {
+  it('true si no hay settings (fail-open)', () => {
+    expect(canUnitOverridePriority(null)).toBe(true)
+    expect(canUnitOverridePriority(undefined)).toBe(true)
+  })
+  it('true cuando la empresa no bloquea', () => {
+    expect(canUnitOverridePriority({ defaultPriorityLocked: false })).toBe(true)
+    expect(canUnitOverridePriority({})).toBe(true)
+  })
+  it('false cuando la empresa bloquea', () => {
+    expect(canUnitOverridePriority({ defaultPriorityLocked: true })).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/useCompanySettings.spec.js
+++ b/frontend/src/__tests__/useCompanySettings.spec.js
@@ -18,6 +18,14 @@ describe('useCompanySettings.load', () => {
     expect(settings.value).toEqual({ defaultPriorityLocked: true })
   })
 
+  it('captura excepciones lanzadas durante el parseo y deja settings nulo', async () => {
+    mockGet.mockResolvedValue({ ok: true, json: async () => { throw new Error('parse') } })
+    const { settings, load } = useCompanySettings()
+    const result = await load()
+    expect(result).toBeNull()
+    expect(settings.value).toBeNull()
+  })
+
   it('mantiene settings nulo cuando la respuesta no es ok', async () => {
     mockGet.mockResolvedValue({ ok: false })
     const { settings, load } = useCompanySettings()

--- a/frontend/src/__tests__/useUnitForm.spec.js
+++ b/frontend/src/__tests__/useUnitForm.spec.js
@@ -36,6 +36,30 @@ beforeEach(() => {
   mockPush.mockReset()
 })
 
+describe('useUnitForm loadFromUnit', () => {
+  it('mapea los campos del backend al formulario', () => {
+    const f = useUnitForm()
+    f.loadFromUnit({ name: 'X', type: 'WAREHOUSE', address: 'a', latitude: 1, longitude: 2, defaultPriority: 'HIGH' })
+    expect(f.name.value).toBe('X')
+    expect(f.unitType.value).toBe('WAREHOUSE')
+    expect(f.address.value).toBe('a')
+    expect(f.latitude.value).toBe(1)
+    expect(f.longitude.value).toBe(2)
+    expect(f.defaultPriority.value).toBe('HIGH')
+  })
+  it('usa defaults seguros con campos ausentes o nulos', () => {
+    const f = useUnitForm()
+    f.loadFromUnit({})
+    expect(f.name.value).toBe('')
+    expect(f.unitType.value).toBeNull()
+    expect(f.defaultPriority.value).toBeNull()
+  })
+  it('no falla si recibe null', () => {
+    const f = useUnitForm()
+    expect(() => f.loadFromUnit(null)).not.toThrow()
+  })
+})
+
 describe('useUnitForm submitUnit', () => {
   it('envía defaultPriority cuando se indica', async () => {
     mockPost.mockResolvedValue({ ok: true })

--- a/frontend/src/composables/useCompanySettings.js
+++ b/frontend/src/composables/useCompanySettings.js
@@ -1,0 +1,28 @@
+// Pequeño composable para leer la configuración heredada de la empresa
+// (DSI-23.1/2/3). Aislado del componente para poder testear el flujo y los
+// fallbacks sin necesidad de montar la vista entera.
+
+import { ref } from 'vue'
+import { useApi } from '@/composables/useApi'
+
+export function useCompanySettings() {
+  const api = useApi()
+  const settings = ref(null)
+
+  async function load() {
+    try {
+      const res = await api.get('/settings')
+      if (res.ok) settings.value = await res.json()
+    } catch (_e) { settings.value = null }
+    return settings.value
+  }
+
+  return { settings, load }
+}
+
+// Devuelve true si una unidad puede sobreescribir la prioridad por defecto
+// según la configuración de empresa cargada. Falla seguro a true si no hay datos.
+export function canUnitOverridePriority(companySettings) {
+  if (!companySettings) return true
+  return !companySettings.defaultPriorityLocked
+}

--- a/frontend/src/composables/useUnitForm.js
+++ b/frontend/src/composables/useUnitForm.js
@@ -88,5 +88,16 @@ export function useUnitForm() {
     }
   }
 
-  return { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit }
+  // Inicializa los campos del formulario desde un objeto unidad recibido del backend.
+  function loadFromUnit(unit) {
+    if (!unit) return
+    name.value = unit.name ?? ''
+    unitType.value = unit.type ?? null
+    address.value = unit.address ?? ''
+    latitude.value = unit.latitude ?? ''
+    longitude.value = unit.longitude ?? ''
+    defaultPriority.value = unit.defaultPriority ?? null
+  }
+
+  return { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit, loadFromUnit }
 }

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -169,6 +169,7 @@ units:
   defaultPriorityHelp: If empty, the company default priority is used
   priorityOverridden: Overridden
   priorityInheritedFromCompany: Inherited from company
+  defaultPriorityLockedByCompany: Locked by the company administrator
   created: Unit created successfully
   updated: Unit updated successfully
   empty: No operational units yet. Create the first one to start managing shipments.
@@ -449,6 +450,8 @@ settings:
   apiKeysSection: API keys
   defaultPriority: Default priority
   defaultPriorityHelp: Applied to new orders when no priority is specified
+  defaultPriorityLock: Lock this setting for all units
+  defaultPriorityLockHelp: If enabled, units cannot override this priority
   currentPlan: Current plan
   availablePlans: Available plans
   selectPlan: Switch to this plan

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -169,6 +169,7 @@ units:
   defaultPriorityHelp: Si se deja vacío se usa la prioridad por defecto de la empresa
   priorityOverridden: Sobreescrita
   priorityInheritedFromCompany: Heredada de la empresa
+  defaultPriorityLockedByCompany: Bloqueado por el administrador de la empresa
   created: Unidad creada correctamente
   updated: Unidad actualizada correctamente
   empty: No hay unidades operativas. Crea la primera para poder gestionar envíos.
@@ -449,6 +450,8 @@ settings:
   apiKeysSection: API keys
   defaultPriority: Prioridad por defecto
   defaultPriorityHelp: Se aplica al crear pedidos cuando no se indica una prioridad
+  defaultPriorityLock: Bloquear esta configuración para todas las unidades
+  defaultPriorityLockHelp: Si está activado, las unidades no podrán sobreescribir esta prioridad
   currentPlan: Plan actual
   availablePlans: Planes disponibles
   selectPlan: Cambiar a este plan

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -10,6 +10,7 @@ import { buildPriorityOptions } from '@/composables/useOrderPriority'
 import { useAppConfig } from '@/composables/useAppConfig'
 import DeleteConfirmPanel from '@/components/DeleteConfirmPanel.vue'
 import ApiKeysSection from './ApiKeysSection.vue'
+import Checkbox from 'primevue/checkbox'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -38,6 +39,7 @@ const editingCompanyId = ref(null)
 const companyName = ref('')
 const activityType = ref(null)
 const defaultPriority = ref(null)
+const defaultPriorityLocked = ref(false)
 const companySaving = ref(false)
 const companyError = ref('')
 const companySuccess = ref(false)
@@ -327,6 +329,7 @@ function startEditCompany(company) {
   companyName.value = company.name
   activityType.value = company.activityType
   defaultPriority.value = company.defaultPriority || null
+  defaultPriorityLocked.value = !!company.defaultPriorityLocked
   companyError.value = ''
   companySuccess.value = false
 }
@@ -342,7 +345,7 @@ async function saveCompany() {
   companySaving.value = true
   companyError.value = ''
   try {
-    const res = await api.put('/settings/company', { name: companyName.value, activityType: activityType.value, defaultPriority: defaultPriority.value })
+    const res = await api.put('/settings/company', { name: companyName.value, activityType: activityType.value, defaultPriority: defaultPriority.value, defaultPriorityLocked: defaultPriorityLocked.value })
     if (res.ok) {
       const updated = await res.json()
       settings.value = updated
@@ -577,6 +580,13 @@ async function copyHandle() {
                         <label>{{ t('settings.defaultPriority') }}</label>
                         <PSelect v-model="defaultPriority" :options="defaultPriorityOptions" option-label="label" option-value="value" fluid show-clear />
                         <small class="field-help">{{ t('settings.defaultPriorityHelp') }}</small>
+                      </div>
+                      <div class="form-field">
+                        <label class="lock-checkbox">
+                          <Checkbox v-model="defaultPriorityLocked" :binary="true" />
+                          {{ t('settings.defaultPriorityLock') }}
+                        </label>
+                        <small class="field-help">{{ t('settings.defaultPriorityLockHelp') }}</small>
                       </div>
                       <PMessage v-if="companyError" severity="error" :closable="false" class="form-message">{{ companyError }}</PMessage>
                       <div class="form-actions">

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { useApi } from '@/composables/useApi'
 import { useUnitForm } from '@/composables/useUnitForm'
 import { buildPriorityOptions } from '@/composables/useOrderPriority'
+import { useCompanySettings, canUnitOverridePriority } from '@/composables/useCompanySettings'
 import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_REGION } from '@/constants/map'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -26,6 +27,7 @@ const isEdit = computed(() => !!unitId.value)
 const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
 const priorityOptions = buildPriorityOptions(t)
 const priorityLockedByCompany = ref(false)
+const { load: loadCompanySettings } = useCompanySettings()
 const loadError = ref('')
 
 const mapEl = ref(null)
@@ -185,13 +187,8 @@ onMounted(async () => {
   await new Promise(r => setTimeout(r, 50)) // aguardar el DOM
   initMap()
   // Cargar lock de prioridad de la empresa para deshabilitar el campo si procede
-  try {
-    const sRes = await api.get('/settings')
-    if (sRes.ok) {
-      const s = await sRes.json()
-      priorityLockedByCompany.value = !!s.defaultPriorityLocked
-    }
-  } catch { /* opcional */ }
+  const s = await loadCompanySettings()
+  priorityLockedByCompany.value = !canUnitOverridePriority(s)
   await loadUnit(unitId.value)
 })
 

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -24,7 +24,7 @@ const api = useApi()
 const unitId = computed(() => route.params.id || null)
 const isEdit = computed(() => !!unitId.value)
 
-const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
+const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit, loadFromUnit } = useUnitForm()
 const priorityOptions = buildPriorityOptions(t)
 const priorityLockedByCompany = ref(false)
 const { load: loadCompanySettings } = useCompanySettings()
@@ -159,12 +159,7 @@ async function loadUnit(id) {
     ])
     if (!unitRes.ok) { loadError.value = t('error.connection'); return }
     const unit = await unitRes.json()
-    name.value = unit.name
-    unitType.value = unit.type
-    address.value = unit.address || ''
-    latitude.value = unit.latitude ?? ''
-    longitude.value = unit.longitude ?? ''
-    defaultPriority.value = unit.defaultPriority || null
+    loadFromUnit(unit)
     if (ordersRes.ok) {
       const orders = await ordersRes.json()
       locationLocked.value = orders.some(o => o.originId === id || o.destinationId === id)

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -25,6 +25,7 @@ const isEdit = computed(() => !!unitId.value)
 
 const { name, unitType, address, latitude, longitude, defaultPriority, error, success, loading, errors, invalids, submitUnit } = useUnitForm()
 const priorityOptions = buildPriorityOptions(t)
+const priorityLockedByCompany = ref(false)
 const loadError = ref('')
 
 const mapEl = ref(null)
@@ -183,6 +184,14 @@ onMounted(async () => {
   // Iniciar mapa primero, luego cargar datos
   await new Promise(r => setTimeout(r, 50)) // aguardar el DOM
   initMap()
+  // Cargar lock de prioridad de la empresa para deshabilitar el campo si procede
+  try {
+    const sRes = await api.get('/settings')
+    if (sRes.ok) {
+      const s = await sRes.json()
+      priorityLockedByCompany.value = !!s.defaultPriorityLocked
+    }
+  } catch { /* opcional */ }
   await loadUnit(unitId.value)
 })
 
@@ -300,8 +309,11 @@ function handleSubmit() {
 
         <div class="form-field">
           <label for="unit-default-priority">{{ t('units.defaultPriority') }}</label>
-          <PSelect id="unit-default-priority" v-model="defaultPriority" :options="priorityOptions" option-label="label" option-value="value" show-clear fluid />
-          <small class="field-hint">{{ t('units.defaultPriorityHelp') }}</small>
+          <PSelect id="unit-default-priority" v-model="defaultPriority" :options="priorityOptions" option-label="label" option-value="value" :disabled="priorityLockedByCompany" show-clear fluid />
+          <small v-if="priorityLockedByCompany" class="field-hint" style="color:#b45309">
+            <i class="pi pi-lock" /> {{ t('units.defaultPriorityLockedByCompany') }}
+          </small>
+          <small v-else class="field-hint">{{ t('units.defaultPriorityHelp') }}</small>
         </div>
 
         <PMessage v-if="error" severity="error" :closable="false" class="form-message">{{ error }}</PMessage>


### PR DESCRIPTION
Permite al administrador de empresa bloquear la prioridad por defecto para que las unidades no puedan sobreescribirla.

Closes #196

## Cambios
**Backend**
- Migración V45: columna `default_priority_locked` (BOOLEAN, default false) en `companies`
- Campo en `Company`, `CompanyUpdateRequest` y `SettingsResponse`
- `OrderService.resolveDefaultPriority` ignora la sobreescritura de la unidad cuando la empresa bloquea
- Test del helper extendido

**Frontend**
- Checkbox "Bloquear esta configuración" en el formulario de empresa
- Campo `defaultPriority` deshabilitado en `UnitFormView` con aviso cuando la empresa lo bloquea
- Traducciones es/en

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versión

* **Nuevas Características**
  * Los administradores de empresa pueden bloquear la configuración de prioridad predeterminada para evitar que las unidades la cambien.
  * Cuando la prioridad predeterminada está bloqueada, aparece como solo lectura en la vista de configuración de unidades, con una indicación visual del bloqueo.
  * Se añadieron controles de configuración y textos de ayuda en los idiomas inglés y español.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->