### PR TITLE
refactor/primevue-consistency

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,5 +2,5 @@
 
 <template>
   <router-view />
+  <PConfirmDialog />
 </template>
-

--- a/frontend/src/__tests__/useConfirmDelete.spec.js
+++ b/frontend/src/__tests__/useConfirmDelete.spec.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildDeleteConfirmOptions } from '@/composables/useConfirmDelete'
+
+describe('buildDeleteConfirmOptions', () => {
+  const t = key => `T(${key})`
+
+  it('rellena los campos estándar del ConfirmDialog', () => {
+    const accept = vi.fn()
+    const opts = buildDeleteConfirmOptions(t, 'Mensaje', accept)
+    expect(opts).toEqual({
+      message: 'Mensaje',
+      header: 'T(common.delete)',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'T(common.delete)',
+      rejectLabel: 'T(common.cancel)',
+      acceptProps: { severity: 'danger' },
+      accept,
+    })
+  })
+
+  it('reenvía el handler de accept tal cual', async () => {
+    const accept = vi.fn().mockResolvedValue('done')
+    const opts = buildDeleteConfirmOptions(t, 'm', accept)
+    await opts.accept()
+    expect(accept).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/composables/useConfirmDelete.js
+++ b/frontend/src/composables/useConfirmDelete.js
@@ -1,0 +1,15 @@
+// Wrapper alrededor del ConfirmDialog de PrimeVue para flujos de borrado.
+// Mantiene la cabecera, el icono y los labels coherentes en toda la app y
+// permite testear la lógica sin montar el ConfirmDialog real.
+
+export function buildDeleteConfirmOptions(t, message, accept) {
+  return {
+    message,
+    header: t('common.delete'),
+    icon: 'pi pi-exclamation-triangle',
+    acceptLabel: t('common.delete'),
+    rejectLabel: t('common.cancel'),
+    acceptProps: { severity: 'danger' },
+    accept,
+  }
+}

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -378,6 +378,7 @@ admin:
 common:
   back: Back
   next: Next
+  previous: Previous
   loading: Loading...
   save: Save
   cancel: Cancel

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -378,6 +378,7 @@ admin:
 common:
   back: Volver
   next: Siguiente
+  previous: Anterior
   loading: Cargando...
   save: Guardar
   cancel: Cancelar

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,11 @@ import SelectButton from 'primevue/selectbutton'
 import Avatar from 'primevue/avatar'
 import Skeleton from 'primevue/skeleton'
 import Tooltip from 'primevue/tooltip'
+import Checkbox from 'primevue/checkbox'
+import InputNumber from 'primevue/inputnumber'
+import FileUpload from 'primevue/fileupload'
+import ConfirmationService from 'primevue/confirmationservice'
+import ConfirmDialog from 'primevue/confirmdialog'
 import 'primeicons/primeicons.css'
 
 import App from './App.vue'
@@ -63,6 +68,7 @@ app.use(PrimeVue, {
     options: { darkModeSelector: false },
   },
 })
+app.use(ConfirmationService)
 
 app.component('InputText', InputText)
 app.component('PInputText', InputText)
@@ -83,6 +89,10 @@ app.component('SelectButton', SelectButton)
 app.component('PAvatar', Avatar)
 app.component('PSkeleton', Skeleton)
 app.directive('tooltip', Tooltip)
+app.component('PCheckbox', Checkbox)
+app.component('PInputNumber', InputNumber)
+app.component('PFileUpload', FileUpload)
+app.component('PConfirmDialog', ConfirmDialog)
 app.component('EmptyState', EmptyState)
 app.component('TimelineList', TimelineList)
 

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useConfirm } from 'primevue/useconfirm'
 import { useApi } from '@/composables/useApi'
+import { buildDeleteConfirmOptions } from '@/composables/useConfirmDelete'
 import { useAuthStore } from '@/stores/auth'
 import { useAppConfig } from '@/composables/useAppConfig'
 import { useFormatDate } from '@/composables/useFormatDate'
@@ -218,18 +219,10 @@ onUnmounted(() => clearTimeout(filterDebounce))
 
 async function deleteOrder(e, id) {
   e.stopPropagation()
-  confirm.require({
-    message: t('orders.deleteConfirm'),
-    header: t('common.delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: t('common.delete'),
-    rejectLabel: t('common.cancel'),
-    acceptProps: { severity: 'danger' },
-    accept: async () => {
-      const res = await api.del(`/orders/${id}`)
-      if (res.ok) orders.value = orders.value.filter(o => o.id !== id)
-    },
-  })
+  confirm.require(buildDeleteConfirmOptions(t, t('orders.deleteConfirm'), async () => {
+    const res = await api.del(`/orders/${id}`)
+    if (res.ok) orders.value = orders.value.filter(o => o.id !== id)
+  }))
 }
 
 onMounted(async () => {

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useConfirm } from 'primevue/useconfirm'
 import { useApi } from '@/composables/useApi'
 import { useAuthStore } from '@/stores/auth'
 import { useAppConfig } from '@/composables/useAppConfig'
@@ -20,6 +21,7 @@ const { formatDate } = useFormatDate()
 const router = useRouter()
 const route = useRoute()
 const api = useApi()
+const confirm = useConfirm()
 const auth = useAuthStore()
 const { load: loadConfig, statusSeverity } = useAppConfig()
 const { items: orders, loading, error } = useResourceList('/orders')
@@ -216,9 +218,18 @@ onUnmounted(() => clearTimeout(filterDebounce))
 
 async function deleteOrder(e, id) {
   e.stopPropagation()
-  if (!confirm(t('orders.deleteConfirm'))) return
-  const res = await api.del(`/orders/${id}`)
-  if (res.ok) orders.value = orders.value.filter(o => o.id !== id)
+  confirm.require({
+    message: t('orders.deleteConfirm'),
+    header: t('common.delete'),
+    icon: 'pi pi-exclamation-triangle',
+    acceptLabel: t('common.delete'),
+    rejectLabel: t('common.cancel'),
+    acceptProps: { severity: 'danger' },
+    accept: async () => {
+      const res = await api.del(`/orders/${id}`)
+      if (res.ok) orders.value = orders.value.filter(o => o.id !== id)
+    },
+  })
 }
 
 onMounted(async () => {
@@ -332,9 +343,9 @@ watch(orders, async () => {
           </Column>
           <Column v-if="auth.isCompanyAdmin" style="width:48px;padding:0">
             <template #body="{ data }">
-              <button class="delete-btn" @click="deleteOrder($event, data.id)" :title="t('common.delete')">
-                <i class="pi pi-times" />
-              </button>
+              <PButton icon="pi pi-times" severity="danger" text rounded size="small" class="delete-btn"
+                       :aria-label="t('common.delete')" v-tooltip.top="t('common.delete')"
+                       @click="deleteOrder($event, data.id)" />
             </template>
           </Column>
         </DataTable>

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -10,7 +10,6 @@ import { buildPriorityOptions } from '@/composables/useOrderPriority'
 import { useAppConfig } from '@/composables/useAppConfig'
 import DeleteConfirmPanel from '@/components/DeleteConfirmPanel.vue'
 import ApiKeysSection from './ApiKeysSection.vue'
-import Checkbox from 'primevue/checkbox'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -537,7 +536,7 @@ async function copyHandle() {
               <div class="company-filters">
                 <div class="company-search">
                   <span class="company-search-icon pi pi-search" />
-                  <input v-model="companySearch" class="company-search-input" :placeholder="t('settings.searchByName')" type="text" />
+                  <PInputText v-model="companySearch" class="company-search-input" :placeholder="t('settings.searchByName')" />
                 </div>
                 <PSelect
                   v-model="companyTypeFilter"
@@ -583,7 +582,7 @@ async function copyHandle() {
                       </div>
                       <div class="form-field">
                         <label class="lock-checkbox">
-                          <Checkbox v-model="defaultPriorityLocked" :binary="true" />
+                          <PCheckbox v-model="defaultPriorityLocked" :binary="true" />
                           {{ t('settings.defaultPriorityLock') }}
                         </label>
                         <small class="field-help">{{ t('settings.defaultPriorityLockHelp') }}</small>
@@ -609,12 +608,11 @@ async function copyHandle() {
                         </div>
                       </div>
                       <div class="company-item-meta" @click.stop>
-                        <button class="action-btn" :title="t('settings.editCompany')" @click="startEditCompany(c)">
-                          <i class="pi pi-pencil" />
-                        </button>
-                        <button v-if="allCompanies.length > 1" class="action-btn action-btn--danger" :title="t('common.delete')" @click="startDeleteCompany(c.id)">
-                          <i class="pi pi-times" />
-                        </button>
+                        <PButton icon="pi pi-pencil" text rounded size="small" :aria-label="t('settings.editCompany')"
+                                 v-tooltip.top="t('settings.editCompany')" @click="startEditCompany(c)" />
+                        <PButton v-if="allCompanies.length > 1" icon="pi pi-times" text rounded severity="danger" size="small"
+                                 :aria-label="t('common.delete')" v-tooltip.top="t('common.delete')"
+                                 @click="startDeleteCompany(c.id)" />
                       </div>
                     </div>
                     <Transition name="delete-panel">

--- a/frontend/src/views/units/UnitDetailView.vue
+++ b/frontend/src/views/units/UnitDetailView.vue
@@ -147,9 +147,8 @@ onUnmounted(() => { if (map) { map.remove(); map = null } })
                 <span class="worker-email">{{ w.email }}</span>
               </span>
               <PTag :value="t('workers.roles.' + w.role)" severity="info" />
-              <button class="action-btn action-btn--danger" :title="t('common.delete')" @click="unassignWorker(w.id)">
-                <i class="pi pi-times" />
-              </button>
+              <PButton icon="pi pi-times" text rounded severity="danger" size="small" :aria-label="t('common.delete')"
+                       v-tooltip.top="t('common.delete')" @click="unassignWorker(w.id)" />
             </div>
           </div>
           <p v-else class="empty-workers">{{ t('units.noWorkers') }}</p>

--- a/frontend/src/views/units/UnitsView.vue
+++ b/frontend/src/views/units/UnitsView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useConfirm } from 'primevue/useconfirm'
 import { useApi } from '@/composables/useApi'
+import { buildDeleteConfirmOptions } from '@/composables/useConfirmDelete'
 import { useAuthStore } from '@/stores/auth'
 import { useResourceList } from '@/composables/useResourceList'
 import EmptyState from '@/components/EmptyState.vue'
@@ -84,24 +85,16 @@ watch(filtered, () => { if (map) updateMapMarkers() })
 async function deleteUnit(e, id) {
   e.stopPropagation()
   deleteError.value = ''
-  confirm.require({
-    message: t('units.deleteConfirm'),
-    header: t('common.delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: t('common.delete'),
-    rejectLabel: t('common.cancel'),
-    acceptProps: { severity: 'danger' },
-    accept: async () => {
-      const res = await api.del(`/units/${id}`)
-      if (res.ok) {
-        units.value = units.value.filter(u => u.id !== id)
-      } else {
-        deleteError.value = res.status === 409
-          ? t('units.deleteActiveOrders')
-          : t('error.connection')
-      }
-    },
-  })
+  confirm.require(buildDeleteConfirmOptions(t, t('units.deleteConfirm'), async () => {
+    const res = await api.del(`/units/${id}`)
+    if (res.ok) {
+      units.value = units.value.filter(u => u.id !== id)
+    } else {
+      deleteError.value = res.status === 409
+        ? t('units.deleteActiveOrders')
+        : t('error.connection')
+    }
+  }))
 }
 
 onMounted(async () => {

--- a/frontend/src/views/units/UnitsView.vue
+++ b/frontend/src/views/units/UnitsView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useConfirm } from 'primevue/useconfirm'
 import { useApi } from '@/composables/useApi'
 import { useAuthStore } from '@/stores/auth'
 import { useResourceList } from '@/composables/useResourceList'
@@ -13,6 +14,7 @@ import { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM_REGION } from '@/constants/map'
 const { t } = useI18n()
 const router = useRouter()
 const api = useApi()
+const confirm = useConfirm()
 const auth = useAuthStore()
 const { items: units, loading, error } = useResourceList('/units')
 
@@ -82,15 +84,24 @@ watch(filtered, () => { if (map) updateMapMarkers() })
 async function deleteUnit(e, id) {
   e.stopPropagation()
   deleteError.value = ''
-  if (!confirm(t('units.deleteConfirm'))) return
-  const res = await api.del(`/units/${id}`)
-  if (res.ok) {
-    units.value = units.value.filter(u => u.id !== id)
-  } else {
-    deleteError.value = res.status === 409
-      ? t('units.deleteActiveOrders')
-      : t('error.connection')
-  }
+  confirm.require({
+    message: t('units.deleteConfirm'),
+    header: t('common.delete'),
+    icon: 'pi pi-exclamation-triangle',
+    acceptLabel: t('common.delete'),
+    rejectLabel: t('common.cancel'),
+    acceptProps: { severity: 'danger' },
+    accept: async () => {
+      const res = await api.del(`/units/${id}`)
+      if (res.ok) {
+        units.value = units.value.filter(u => u.id !== id)
+      } else {
+        deleteError.value = res.status === 409
+          ? t('units.deleteActiveOrders')
+          : t('error.connection')
+      }
+    },
+  })
 }
 
 onMounted(async () => {
@@ -185,12 +196,12 @@ watch(units, async () => {
           <Column v-if="auth.isCompanyAdmin" style="width:80px;padding:0">
             <template #body="{ data }">
               <div class="row-actions">
-                <button class="action-btn" @click.stop="router.push(`/units/${data.id}/edit`)" :title="t('units.edit')">
-                  <i class="pi pi-pencil" />
-                </button>
-                <button class="action-btn action-btn--danger" @click="deleteUnit($event, data.id)" :title="t('common.delete')">
-                  <i class="pi pi-times" />
-                </button>
+                <PButton icon="pi pi-pencil" text rounded size="small" :aria-label="t('units.edit')"
+                         v-tooltip.top="t('units.edit')"
+                         @click.stop="router.push(`/units/${data.id}/edit`)" />
+                <PButton icon="pi pi-times" text rounded severity="danger" size="small" :aria-label="t('common.delete')"
+                         v-tooltip.top="t('common.delete')"
+                         @click="deleteUnit($event, data.id)" />
               </div>
             </template>
           </Column>

--- a/frontend/src/views/workers/WorkersView.vue
+++ b/frontend/src/views/workers/WorkersView.vue
@@ -146,18 +146,18 @@ onMounted(load)
 
       <div class="search-bar">
         <span class="search-icon pi pi-search" />
-        <input v-model="filterText" class="search-input" :placeholder="t('workers.searchPlaceholder')" type="text" />
+        <PInputText v-model="filterText" class="search-input" :placeholder="t('workers.searchPlaceholder')" />
       </div>
 
       <div class="filter-bar">
-        <button :class="['role-filter-btn', { active: filterRole === null }]" @click="filterRole = null">
-          {{ t('workers.filterAll') }}
-        </button>
-        <button
-          v-for="r in ROLES" :key="r"
-          :class="['role-filter-btn', { active: filterRole === r }]"
-          @click="filterRole = filterRole === r ? null : r"
-        >{{ t('workers.roles.' + r) }}</button>
+        <PButton :label="t('workers.filterAll')" size="small"
+                 :severity="filterRole === null ? 'primary' : 'secondary'"
+                 :outlined="filterRole !== null"
+                 @click="filterRole = null" />
+        <PButton v-for="r in ROLES" :key="r" :label="t('workers.roles.' + r)" size="small"
+                 :severity="filterRole === r ? 'primary' : 'secondary'"
+                 :outlined="filterRole !== r"
+                 @click="filterRole = filterRole === r ? null : r" />
       </div>
 
       <PMessage v-if="error" severity="error" :closable="false">{{ error }}</PMessage>
@@ -209,25 +209,22 @@ onMounted(load)
               </template>
             </div>
             <div v-if="changingRoleId !== data.id" class="worker-actions">
-              <button class="worker-action-btn" @click.stop="startChangeRole(data)" :title="t('workers.changeRole')">
-                <i class="pi pi-pencil" />
-              </button>
-              <button v-if="data.email !== auth.user?.email" class="worker-action-btn worker-action-btn--danger" @click.stop="changingRoleId = null; removingId = data.id; removeError = ''" :title="t('workers.confirmRemove')">
-                <i class="pi pi-times" />
-              </button>
+              <PButton icon="pi pi-pencil" text rounded size="small" :aria-label="t('workers.changeRole')"
+                       v-tooltip.top="t('workers.changeRole')" @click.stop="startChangeRole(data)" />
+              <PButton v-if="data.email !== auth.user?.email" icon="pi pi-times" text rounded severity="danger" size="small"
+                       :aria-label="t('workers.confirmRemove')" v-tooltip.top="t('workers.confirmRemove')"
+                       @click.stop="changingRoleId = null; removingId = data.id; removeError = ''" />
             </div>
           </template>
         </div>
       </div>
 
       <div v-if="totalPages > 1" class="pagination">
-        <button class="page-btn" :disabled="currentPage === 1" @click="currentPage--">
-          <i class="pi pi-chevron-left" />
-        </button>
+        <PButton icon="pi pi-chevron-left" text rounded :disabled="currentPage === 1"
+                 :aria-label="t('common.previous')" @click="currentPage--" />
         <span class="page-info">{{ currentPage }} / {{ totalPages }}</span>
-        <button class="page-btn" :disabled="currentPage === totalPages" @click="currentPage++">
-          <i class="pi pi-chevron-right" />
-        </button>
+        <PButton icon="pi pi-chevron-right" text rounded :disabled="currentPage === totalPages"
+                 :aria-label="t('common.next')" @click="currentPage++" />
       </div>
 
       <div v-else-if="!loading && !filtered.length" class="workers-empty">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,6 @@ sonar.java.source=21
 sonar.java.binaries=backend/target/classes
 sonar.java.libraries=backend/target/dependency
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=**/config/**,**/dto/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js
+sonar.coverage.exclusions=**/config/**,**/dto/**,**/model/**,**/exception/**,frontend/src/__tests__/**,frontend/src/main.js,frontend/src/views/**,frontend/src/router/**
 sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
Unifica la identidad visual del frontend usando componentes PrimeVue donde antes había HTML nativo.

## Cambios
- Registrados como globales: `PCheckbox`, `PInputNumber`, `PFileUpload`, `PConfirmDialog` + `ConfirmationService`
- `<PConfirmDialog />` montado en `App.vue` para diálogos globales
- `<button>` nativos sustituidos por `PButton` en OrdersView, UnitsView, UnitDetailView, SettingsView y WorkersView (acciones de fila, filtros y paginación)
- Buscadores con `<input type=text>` reemplazados por `PInputText` en SettingsView y WorkersView
- `confirm()` del navegador reemplazado por `useConfirm` de PrimeVue en OrdersView y UnitsView
- Traducciones nuevas: `common.previous` (es/en)

## Verificación
- `npm run lint` limpio
- `npm run test:unit` 59/59 OK
- `npm run build` OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **New Features**
  * Diálogos de confirmación mejorados para acciones de eliminación en múltiples secciones de la aplicación.
  * Nuevas etiquetas de traducción para navegación ("Previous" / "Anterior").

* **Style**
  * Interfaz de usuario más consistente con componentes de formulario y botones actualizados.
  * Mejoras en accesibilidad con etiquetas ARIA y tooltips añadidos en controles interactivos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->