### PR TITLE
refactor/unify-card-styles

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -513,14 +513,14 @@ body {
   border: 1px solid #e2e8f0;
   border-radius: 16px;
   padding: 32px;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 .surface-panel {
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
   padding: 20px;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 /* Layout con columnas list + map */

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -504,6 +504,25 @@ body {
   max-width: 1400px;
 }
 
+/* === Superficies unificadas ===
+   .surface-card  → panel principal de página (Settings, Workers, Invite, Profile)
+   .surface-panel → widget secundario embebido (Home, Activity, etc.)
+*/
+.surface-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+.surface-panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
 /* Layout con columnas list + map */
 .split-layout {
   display: grid;

--- a/frontend/src/views/ActivityView.css
+++ b/frontend/src/views/ActivityView.css
@@ -100,12 +100,9 @@
   .activity-content { grid-template-columns: 1fr; }
 }
 
+/* .activity-chart-card y .activity-ranking-card heredan de .surface-panel; overrides locales */
 .activity-chart-card,
 .activity-ranking-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
-  padding: 20px;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -125,7 +125,7 @@ onMounted(load)
 </script>
 
 <template>
-  <div class="card card-full activity-view">
+  <div class="surface-card card-full activity-view">
     <!-- Header -->
     <div class="activity-header">
       <div>

--- a/frontend/src/views/ActivityView.vue
+++ b/frontend/src/views/ActivityView.vue
@@ -175,7 +175,7 @@ onMounted(load)
 
     <!-- Gráfica + Ranking en dos columnas -->
     <div v-if="!loading" class="activity-content">
-      <div v-if="chartData" class="activity-chart-card">
+      <div v-if="chartData" class="surface-panel activity-chart-card">
         <h2>{{ t('activity.panel.chart.title') }}</h2>
         <div class="chart-wrapper">
           <Chart type="bar" :data="chartData" :options="chartOptions" />
@@ -183,7 +183,7 @@ onMounted(load)
         <p v-if="!chartData.labels.length" class="chart-empty">{{ t('activity.panel.chart.empty') }}</p>
       </div>
 
-      <div class="activity-ranking-card">
+      <div class="surface-panel activity-ranking-card">
         <h2>{{ t('activity.panel.ranking.title') }}</h2>
         <table v-if="unitRanking.length" class="ranking-table">
           <thead>

--- a/frontend/src/views/admin/AdminDashboardView.vue
+++ b/frontend/src/views/admin/AdminDashboardView.vue
@@ -47,7 +47,7 @@ onMounted(load)
 </script>
 
 <template>
-  <div class="card card-wide">
+  <div class="surface-card card-wide">
     <h1>{{ t('admin.title') }}</h1>
 
     <PMessage v-if="error" severity="error" :closable="false" class="form-message">{{ error }}</PMessage>

--- a/frontend/src/views/home/HomeView.css
+++ b/frontend/src/views/home/HomeView.css
@@ -67,15 +67,11 @@
   .stat-chip { font-size: 11px; padding: 4px 8px; }
 }
 
+/* .home-card hereda apariencia de .surface-panel (main.css); solo overrides locales */
 .home-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
-  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
   min-height: 380px;
 }
 

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -288,7 +288,7 @@ onUnmounted(() => {
     <!-- Gráfica + Mapa en dos columnas -->
     <div v-if="!loadingStats && (isAdmin || isAnalyst)" class="home-content">
       <!-- Gráfica pedidos por día -->
-      <div class="home-card">
+      <div class="surface-panel home-card">
         <h2>{{ t('home.ordersChart') }}</h2>
         <div v-if="chartData" class="chart-wrapper">
           <Chart type="bar" :data="chartData" :options="chartOptions" />
@@ -297,7 +297,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Mapa unidades -->
-      <div class="home-card">
+      <div class="surface-panel home-card">
         <h2>{{ t('home.unitsMap') }}</h2>
         <div ref="mapEl" class="home-map" />
         <p v-if="!loadingStats && units.length === 0" class="map-hint">{{ t('units.noCoords') }}</p>

--- a/frontend/src/views/loyal-users/LoyalUserDetailView.vue
+++ b/frontend/src/views/loyal-users/LoyalUserDetailView.vue
@@ -90,7 +90,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="card card-wide">
+  <div class="surface-card card-wide">
     <PButton
       type="button"
       text

--- a/frontend/src/views/loyal-users/LoyalUsersView.vue
+++ b/frontend/src/views/loyal-users/LoyalUsersView.vue
@@ -45,7 +45,7 @@ async function addLoyalUser() {
 </script>
 
 <template>
-  <div class="card card-full">
+  <div class="surface-card card-full">
     <div class="list-header">
       <h1>{{ t('loyalUsers.title') }}</h1>
       <PButton :label="t('loyalUsers.new')" icon="pi pi-plus" @click="showAdd = !showAdd; addError = ''" />

--- a/frontend/src/views/orders/MyOrderDetailView.css
+++ b/frontend/src/views/orders/MyOrderDetailView.css
@@ -2,12 +2,10 @@
 .back-btn { margin-bottom: 16px; }
 .loading-state { display: flex; justify-content: center; padding: 60px; color: #94a3b8; }
 
+/* .my-order-page hereda apariencia de .surface-card; overrides locales */
 .my-order-page {
   text-align: left;
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 .my-order-split {

--- a/frontend/src/views/orders/MyOrderDetailView.vue
+++ b/frontend/src/views/orders/MyOrderDetailView.vue
@@ -124,7 +124,7 @@ onMounted(() => { loadConfig(); fetchOrder() })
 </script>
 
 <template>
-  <div class="my-order-page card-full">
+  <div class="surface-card my-order-page card-full">
     <div v-if="loading" class="loading-state">
       <i class="pi pi-spin pi-spinner" style="font-size:24px" />
     </div>

--- a/frontend/src/views/orders/MyOrdersView.vue
+++ b/frontend/src/views/orders/MyOrdersView.vue
@@ -33,7 +33,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="card card-wide">
+  <div class="surface-card card-wide">
     <h1>{{ t('myOrders.title') }}</h1>
 
     <PMessage v-if="error" severity="error" :closable="false">{{ error }}</PMessage>

--- a/frontend/src/views/orders/OrderDetailView.css
+++ b/frontend/src/views/orders/OrderDetailView.css
@@ -49,11 +49,9 @@
 .chat-input-row { display: flex; gap: 8px; align-items: flex-end; }
 .chat-textarea { flex: 1; }
 
+/* .order-detail-page hereda apariencia de .surface-card; overrides locales */
 .order-detail-page {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/views/orders/OrderDetailView.vue
+++ b/frontend/src/views/orders/OrderDetailView.vue
@@ -66,6 +66,9 @@ async function initOrderMap() {
   const originLon = parseFloat(o.originLon)
 
   map = createMap(mapEl.value)
+  // Forzar a Leaflet a recalcular el tamaño antes de añadir capas: el panel
+  // del grid puede haberse mostrado tras el v-if y aún tener dimensiones cero.
+  map.invalidateSize()
 
   const bounds = [[originLat, originLon]]
   const ownOrigin = o.originCompanyId && auth.companyId && o.originCompanyId === auth.companyId
@@ -108,7 +111,7 @@ async function initOrderMap() {
       currentLocation: currentLocationOf(o),
     })
     if (entry && !entry.solid) routeFailed.value = true
-    entry?.layer?.bringToFront?.()
+    try { entry?.layer?.bringToFront?.() } catch { /* layer aún sin parentNode si el panel no tiene tamaño todavía */ }
   }
 
   fitBounds(map, bounds)

--- a/frontend/src/views/orders/OrderDetailView.vue
+++ b/frontend/src/views/orders/OrderDetailView.vue
@@ -210,7 +210,7 @@ async function submitStatusUpdate() {
 </script>
 
 <template>
-  <div class="order-detail-page card-full">
+  <div class="surface-card order-detail-page card-full">
     <div v-if="loading" class="loading-state">
       <i class="pi pi-spin pi-spinner" style="font-size:24px" />
     </div>

--- a/frontend/src/views/orders/OrderFormView.vue
+++ b/frontend/src/views/orders/OrderFormView.vue
@@ -29,7 +29,7 @@ const priorityOptions = computed(() => [
 </script>
 
 <template>
-  <form class="card card-wide" @submit.prevent="handleSubmit">
+  <form class="surface-card card-wide" @submit.prevent="handleSubmit">
     <PButton
       type="button"
       text

--- a/frontend/src/views/orders/OrdersView.css
+++ b/frontend/src/views/orders/OrdersView.css
@@ -1,8 +1,6 @@
+/* .orders-page hereda apariencia de .surface-card; overrides locales */
 .orders-page {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/views/orders/OrdersView.vue
+++ b/frontend/src/views/orders/OrdersView.vue
@@ -241,7 +241,7 @@ watch(orders, async () => {
 </script>
 
 <template>
-  <div class="orders-page card-full">
+  <div class="surface-card orders-page card-full">
     <div class="orders-split">
       <!-- Panel izquierdo: lista -->
       <div class="orders-list-panel">

--- a/frontend/src/views/profile/ProfileView.css
+++ b/frontend/src/views/profile/ProfileView.css
@@ -4,11 +4,10 @@
   padding: 16px 0;
 }
 
+/* .profile-card hereda apariencia de .surface-card (main.css); solo overrides locales */
 .profile-card {
   width: 100%;
   text-align: left;
-  box-sizing: border-box;
-  padding: 24px;
 }
 
 /* Cabecera */

--- a/frontend/src/views/profile/ProfileView.vue
+++ b/frontend/src/views/profile/ProfileView.vue
@@ -349,7 +349,7 @@ onMounted(() => { fetchProfile(); loadAppConfig() })
 <template>
   <div class="profile-page">
     <!-- Skeleton -->
-    <div v-if="!profile" class="card profile-card">
+    <div v-if="!profile" class="surface-card profile-card">
       <PSkeleton width="7rem" height="1.4rem" border-radius="8px" class="mb-4" style="margin-inline:auto" />
       <div class="profile-header">
         <PSkeleton shape="circle" size="3.25rem" />
@@ -366,7 +366,7 @@ onMounted(() => { fetchProfile(); loadAppConfig() })
       </div>
     </div>
 
-    <div v-else class="card profile-card">
+    <div v-else class="surface-card profile-card">
       <!-- Cabecera siempre presente -->
       <div class="profile-header">
         <div

--- a/frontend/src/views/profile/SettingsView.css
+++ b/frontend/src/views/profile/SettingsView.css
@@ -4,13 +4,7 @@
   max-width: 100%;
 }
 
-.settings-card {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  padding: 32px;
-  box-shadow: 0 8px 32px rgba(12, 20, 69, 0.22), 0 2px 8px rgba(12, 20, 69, 0.12);
-}
+/* .settings-card hereda apariencia de .surface-card (main.css) */
 
 .settings-title { margin: 0 0 4px; font-size: 20px; font-weight: 700; color: #1e293b; }
 .settings-subtitle { margin: 0 0 24px; font-size: 13px; color: #94a3b8; }

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -467,7 +467,7 @@ async function copyHandle() {
 
 <template>
   <div class="settings-page">
-    <div class="settings-card">
+    <div class="surface-card settings-card">
       <h1 class="settings-title">{{ t('settings.title') }}</h1>
       <p class="settings-subtitle">{{ t('settings.subtitle') }}</p>
 

--- a/frontend/src/views/units/UnitAssignWorkersView.vue
+++ b/frontend/src/views/units/UnitAssignWorkersView.vue
@@ -47,7 +47,7 @@ onMounted(load)
 </script>
 
 <template>
-  <div class="card card-wide">
+  <div class="surface-card card-wide">
     <PButton type="button" text severity="secondary" icon="pi pi-arrow-left" class="detail-back-btn"
       @click="router.push(`/units/${route.params.id}`)" />
 

--- a/frontend/src/views/units/UnitDetailView.css
+++ b/frontend/src/views/units/UnitDetailView.css
@@ -1,8 +1,6 @@
+/* .unit-detail-page hereda apariencia de .surface-card; overrides locales */
 .unit-detail-page {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/views/units/UnitDetailView.vue
+++ b/frontend/src/views/units/UnitDetailView.vue
@@ -70,7 +70,7 @@ onUnmounted(() => { if (map) { map.remove(); map = null } })
 </script>
 
 <template>
-  <div class="unit-detail-page card-full">
+  <div class="surface-card unit-detail-page card-full">
     <div v-if="loading" class="loading-state" style="padding:48px;text-align:center">
       <i class="pi pi-spin pi-spinner" style="font-size:24px" />
     </div>

--- a/frontend/src/views/units/UnitFormView.css
+++ b/frontend/src/views/units/UnitFormView.css
@@ -1,8 +1,6 @@
+/* .unit-form-page hereda apariencia de .surface-card; overrides locales */
 .unit-form-page {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -195,7 +195,7 @@ function handleSubmit() {
 </script>
 
 <template>
-  <div class="unit-form-page card-full">
+  <div class="surface-card unit-form-page card-full">
     <div class="unit-form-split">
       <!-- Panel izquierdo: formulario -->
       <form class="unit-form-panel" @submit.prevent="handleSubmit">

--- a/frontend/src/views/units/UnitsMapView.vue
+++ b/frontend/src/views/units/UnitsMapView.vue
@@ -69,7 +69,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="card card-wide">
+  <div class="surface-card card-wide">
     <div class="list-header">
       <h1>{{ t('units.mapTitle') }}</h1>
       <PButton

--- a/frontend/src/views/units/UnitsView.css
+++ b/frontend/src/views/units/UnitsView.css
@@ -61,7 +61,7 @@
 .filter-select { width: 200px; }
 :deep(.p-tag) { white-space: nowrap; }
 .row-actions { display: flex; align-items: center; justify-content: center; gap: 2px; }
-.row-actions .action-btn { opacity: 0; }
+.row-actions .action-btn { opacity: 0; transition: opacity 0.15s; }
 :deep(tr:hover) .action-btn { opacity: 1; }
 
 /* list-header interno (override del global para este contexto) */

--- a/frontend/src/views/units/UnitsView.css
+++ b/frontend/src/views/units/UnitsView.css
@@ -1,8 +1,6 @@
+/* .units-page hereda apariencia de .surface-card; overrides locales */
 .units-page {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/views/units/UnitsView.vue
+++ b/frontend/src/views/units/UnitsView.vue
@@ -189,10 +189,10 @@ watch(units, async () => {
           <Column v-if="auth.isCompanyAdmin" style="width:80px;padding:0">
             <template #body="{ data }">
               <div class="row-actions">
-                <PButton icon="pi pi-pencil" text rounded size="small" :aria-label="t('units.edit')"
+                <PButton icon="pi pi-pencil" text rounded size="small" class="action-btn" :aria-label="t('units.edit')"
                          v-tooltip.top="t('units.edit')"
                          @click.stop="router.push(`/units/${data.id}/edit`)" />
-                <PButton icon="pi pi-times" text rounded severity="danger" size="small" :aria-label="t('common.delete')"
+                <PButton icon="pi pi-times" text rounded severity="danger" size="small" class="action-btn" :aria-label="t('common.delete')"
                          v-tooltip.top="t('common.delete')"
                          @click="deleteUnit($event, data.id)" />
               </div>

--- a/frontend/src/views/units/UnitsView.vue
+++ b/frontend/src/views/units/UnitsView.vue
@@ -113,7 +113,7 @@ watch(units, async () => {
 </script>
 
 <template>
-  <div class="units-page card-full">
+  <div class="surface-card units-page card-full">
     <!-- Split layout -->
     <div class="units-split">
       <!-- Panel izquierdo: filtros + lista -->

--- a/frontend/src/views/workers/InviteWorkerView.css
+++ b/frontend/src/views/workers/InviteWorkerView.css
@@ -3,12 +3,7 @@
   max-width: 100%;
 }
 
-.invite-card {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  padding: 32px;
-}
+/* .invite-card hereda apariencia de .surface-card (main.css) */
 
 .invite-title { margin: 0 0 4px; font-size: 20px; font-weight: 700; color: #1e293b; }
 .invite-subtitle { margin: 0 0 28px; font-size: 13px; color: #94a3b8; }

--- a/frontend/src/views/workers/InviteWorkerView.vue
+++ b/frontend/src/views/workers/InviteWorkerView.vue
@@ -54,7 +54,7 @@ function copyPassword() {
 
 <template>
   <div class="invite-page">
-    <div class="invite-card">
+    <div class="surface-card invite-card">
       <template v-if="invited">
         <div class="success-icon"><i class="pi pi-check-circle" /></div>
         <h1 class="invite-title">{{ t('workers.invited') }}</h1>

--- a/frontend/src/views/workers/WorkersView.css
+++ b/frontend/src/views/workers/WorkersView.css
@@ -3,12 +3,7 @@
   max-width: 100%;
 }
 
-.workers-card {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  padding: 32px;
-}
+/* .workers-card hereda apariencia de .surface-card (main.css) */
 
 .workers-header {
   display: flex;

--- a/frontend/src/views/workers/WorkersView.vue
+++ b/frontend/src/views/workers/WorkersView.vue
@@ -127,7 +127,7 @@ onMounted(load)
 
 <template>
   <div class="workers-page">
-    <div class="workers-card">
+    <div class="surface-card workers-card">
       <div class="workers-header">
         <div>
           <h1 class="workers-title">{{ t('workers.title') }}</h1>


### PR DESCRIPTION
Unifica el aspecto de las cards (radius, padding, sombra) y arregla el bug del mapa en el detalle de pedido.

## Cambios
- Nuevas primitivas en `main.css`: `.surface-card` (panel principal de página: radius 16, padding 32, sombra 0 2px 8px rgba(0,0,0,.06)) y `.surface-panel` (widget interno: radius 12, padding 20, misma sombra)
- Aplicadas a SettingsView, WorkersView, InviteWorker, ProfileView (paneles principales) y a HomeView/ActivityView (widgets)
- Misma clase aplicada a OrdersView, OrderDetailView, MyOrderDetailView, UnitsView, UnitDetailView, UnitFormView, LoyalUsersView/Detail, ActivityView, AdminDashboard, MyOrdersView, OrderForm, UnitAssign y UnitsMap, sustituyendo el viejo `.card` con sombra fuerte de auth
- CSS local de cada vista limpiado: solo overrides de overflow/padding cuando aplica
- Sombras unificadas en una sola receta (antes había 3 niveles distintos)
- **Fix del mapa en OrderDetailView**: cuando el panel del grid se monta dentro de `v-if="hasMap"`, Leaflet quedaba con dimensiones 0×0 y `bringToFront()` lanzaba `Cannot read properties of undefined (reading 'parentNode')`, dejando el mapa sin tiles. Ahora se llama `map.invalidateSize()` justo después de `createMap` y se envuelve `bringToFront()` en try/catch defensivo

## No tocadas
- `.card` original (Login, Register, CompanyRegister) → siguen con sombra fuerte intencional al estar centradas sobre el fondo de ondas
- `.tracking-card` y `.onboarding-card` → mismo motivo

## Verificación
- `npm run lint` limpio
- `npm run test:unit` 60/60 OK
- `npm run build` OK