### PR TITLE
fix/validations-and-permissions

### DIFF
--- a/backend/src/main/java/com/delivera/dto/worker/ChangeRoleRequest.java
+++ b/backend/src/main/java/com/delivera/dto/worker/ChangeRoleRequest.java
@@ -1,5 +1,6 @@
 package com.delivera.dto.worker;
 
+import com.delivera.model.WorkerRole;
 import jakarta.validation.constraints.NotNull;
 
-public record ChangeRoleRequest(@NotNull String role) {}
+public record ChangeRoleRequest(@NotNull WorkerRole role) {}

--- a/backend/src/main/java/com/delivera/dto/worker/WorkerInviteRequest.java
+++ b/backend/src/main/java/com/delivera/dto/worker/WorkerInviteRequest.java
@@ -1,5 +1,6 @@
 package com.delivera.dto.worker;
 
+import com.delivera.model.WorkerRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,4 +8,4 @@ import jakarta.validation.constraints.Size;
 
 public record WorkerInviteRequest(
         @NotBlank @Email @Size(max = 255) String email,
-        @NotNull String role) {}
+        @NotNull WorkerRole role) {}

--- a/backend/src/main/java/com/delivera/exception/FileTooLargeException.java
+++ b/backend/src/main/java/com/delivera/exception/FileTooLargeException.java
@@ -1,0 +1,7 @@
+package com.delivera.exception;
+
+public class FileTooLargeException extends RuntimeException {
+    public FileTooLargeException() {
+        super("File exceeds the maximum allowed size");
+    }
+}

--- a/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
@@ -44,7 +44,8 @@ public class GlobalExceptionHandler {
         Map.entry(LoyalUserCannotBeWorkerException.class,   new Mapping(CONFLICT,             "LOYAL_USER_CANNOT_BE_WORKER")),
         Map.entry(MissingRecipientAddressException.class, new Mapping(UNPROCESSABLE_ENTITY, "MISSING_RECIPIENT_ADDRESS")),
         Map.entry(RateLimitExceededException.class,       new Mapping(TOO_MANY_REQUESTS,    "RATE_LIMIT_EXCEEDED")),
-        Map.entry(ApiKeyNotFoundException.class,          new Mapping(NOT_FOUND,            "API_KEY_NOT_FOUND"))
+        Map.entry(ApiKeyNotFoundException.class,          new Mapping(NOT_FOUND,            "API_KEY_NOT_FOUND")),
+        Map.entry(FileTooLargeException.class,            new Mapping(PAYLOAD_TOO_LARGE,    "FILE_TOO_LARGE"))
     );
 
     @ExceptionHandler(RuntimeException.class)

--- a/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/delivera/exception/GlobalExceptionHandler.java
@@ -135,7 +135,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleMalformedJson(org.springframework.http.converter.HttpMessageNotReadableException ex) {
-        log.warn("Malformed request body: {}", ex.getMostSpecificCause().getMessage());
+        Throwable cause = ex.getMostSpecificCause();
+        log.warn("Malformed request body: {}", cause.getMessage());
+        // Diferenciar errores de tipo numérico — típicos por usar coma decimal en vez de punto.
+        if (cause instanceof com.fasterxml.jackson.databind.exc.InvalidFormatException ife
+                && ife.getTargetType() != null
+                && Number.class.isAssignableFrom(ife.getTargetType())) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("INVALID_NUMBER_FORMAT"));
+        }
         return ResponseEntity.badRequest().body(new ErrorResponse("MALFORMED_REQUEST"));
     }
 

--- a/backend/src/main/java/com/delivera/service/AppConfigService.java
+++ b/backend/src/main/java/com/delivera/service/AppConfigService.java
@@ -28,6 +28,22 @@ public class AppConfigService {
         this.fileMaxUploadBytes = fileMaxUploadBytes;
     }
 
+    public long getFileMaxUploadBytes() {
+        return fileMaxUploadBytes;
+    }
+
+    /**
+     * Valida que el contenido base64 (data URL incluido) no supere el límite.
+     * Una cadena base64 de N caracteres representa ~0.75 N bytes binarios.
+     */
+    public void checkUploadSize(String base64Data) {
+        if (base64Data == null) return;
+        long approxBytes = (long) (base64Data.length() * 0.75);
+        if (approxBytes > fileMaxUploadBytes) {
+            throw new com.delivera.exception.FileTooLargeException();
+        }
+    }
+
     @Transactional(readOnly = true)
     public AppConfigResponse getConfig() {
         List<OrderStatusConfigDto> statuses = statusConfigRepository.findAllByOrderBySortOrderAsc()

--- a/backend/src/main/java/com/delivera/service/SettingsService.java
+++ b/backend/src/main/java/com/delivera/service/SettingsService.java
@@ -44,6 +44,8 @@ public class SettingsService {
     private SecurityUtils securityUtils;
     @Autowired
     private SubscriptionService subscriptionService;
+    @Autowired
+    private AppConfigService appConfigService;
 
     private Company currentCompany() {
         return companyRepository.findById(securityUtils.getCurrentCompanyId())
@@ -139,6 +141,7 @@ public class SettingsService {
 
     @Transactional
     public CompanySummary updateCompanyLogo(String logoData) {
+        appConfigService.checkUploadSize(logoData);
         Company c = currentCompany();
         c.setLogoData(logoData);
         companyRepository.save(c);

--- a/backend/src/main/java/com/delivera/service/UserService.java
+++ b/backend/src/main/java/com/delivera/service/UserService.java
@@ -23,6 +23,9 @@ public class UserService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private AppConfigService appConfigService;
+
     @Transactional(readOnly = true)
     public ProfileResponse getProfile(String email) {
         User user = userRepository.findByEmail(email)
@@ -54,6 +57,7 @@ public class UserService {
 
     @Transactional
     public ProfileResponse updateAvatar(String email, String avatarData) {
+        appConfigService.checkUploadSize(avatarData);
         User user = userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
         user.setAvatarData(avatarData);

--- a/backend/src/main/java/com/delivera/service/WorkerService.java
+++ b/backend/src/main/java/com/delivera/service/WorkerService.java
@@ -55,7 +55,7 @@ public class WorkerService {
         subscriptionService.checkWorkerLimit(companyId);
 
         String email = req.email().toLowerCase().trim();
-        WorkerRole role = WorkerRole.valueOf(req.role());
+        WorkerRole role = req.role();
 
         if (workerRepository.findByUserEmailAndCompanyId(email, companyId).isPresent()) {
             throw new WorkerAlreadyExistsException();
@@ -95,7 +95,7 @@ public class WorkerService {
         Worker worker = workerRepository.findByIdAndCompanyId(workerId, companyId)
                 .orElseThrow(WorkerNotFoundException::new);
 
-        WorkerRole newRole = WorkerRole.valueOf(req.role());
+        WorkerRole newRole = req.role();
 
         if (worker.getRole() == WorkerRole.COMPANY_ADMIN && newRole != WorkerRole.COMPANY_ADMIN) {
             if (workerRepository.countByCompanyIdAndRole(companyId, WorkerRole.COMPANY_ADMIN) <= 1) {

--- a/backend/src/test/java/com/delivera/service/AppConfigServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/AppConfigServiceTest.java
@@ -73,4 +73,23 @@ class AppConfigServiceTest {
         assertThatThrownBy(() -> appConfigService.validateTransition("UNKNOWN", "ANY"))
                 .isInstanceOf(InvalidStatusTransitionException.class);
     }
+
+    @Test
+    void getFileMaxUploadBytes_returnsConfiguredValue() {
+        assertThat(appConfigService.getFileMaxUploadBytes()).isEqualTo(2097152L);
+    }
+
+    @Test
+    void checkUploadSize_acceptsNullAndSmallPayload() {
+        appConfigService.checkUploadSize(null);
+        appConfigService.checkUploadSize("data:image/png;base64,YWJj"); // ~3 bytes
+    }
+
+    @Test
+    void checkUploadSize_throwsWhenExceedsLimit() {
+        // 3 MB de base64 ≈ 2.25 MB binarios → debe superar el límite de 2 MB
+        String payload = "x".repeat(3 * 1024 * 1024);
+        assertThatThrownBy(() -> appConfigService.checkUploadSize(payload))
+                .isInstanceOf(com.delivera.exception.FileTooLargeException.class);
+    }
 }

--- a/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/SettingsServiceTest.java
@@ -51,6 +51,8 @@ class SettingsServiceTest {
     private SecurityUtils securityUtils;
     @Mock
     private SubscriptionService subscriptionService;
+    @Mock
+    private AppConfigService appConfigService;
     @InjectMocks
     private SettingsService settingsService;
 

--- a/backend/src/test/java/com/delivera/service/UserServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/UserServiceTest.java
@@ -31,6 +31,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private AppConfigService appConfigService;
     @InjectMocks
     private UserService userService;
 

--- a/backend/src/test/java/com/delivera/service/WorkerServiceTest.java
+++ b/backend/src/test/java/com/delivera/service/WorkerServiceTest.java
@@ -71,7 +71,7 @@ class WorkerServiceTest {
         when(companyRepository.findById(companyId)).thenReturn(Optional.of(company));
         when(workerRepository.save(any())).thenReturn(worker);
 
-        WorkerResponse response = workerService.invite(new WorkerInviteRequest("worker@test.com", "OPERATOR"));
+        WorkerResponse response = workerService.invite(new WorkerInviteRequest("worker@test.com", WorkerRole.OPERATOR));
 
         assertThat(response.email()).isEqualTo("worker@test.com");
         assertThat(response.tempPassword()).isNull();
@@ -98,7 +98,7 @@ class WorkerServiceTest {
 
         when(workerRepository.save(any())).thenReturn(savedWorker);
 
-        WorkerResponse response = workerService.invite(new WorkerInviteRequest("new@test.com", "ANALYST"));
+        WorkerResponse response = workerService.invite(new WorkerInviteRequest("new@test.com", WorkerRole.ANALYST));
 
         assertThat(response.tempPassword()).isNotNull();
         verify(userRepository).save(any(User.class));
@@ -108,7 +108,7 @@ class WorkerServiceTest {
     void invite_alreadyWorker_throwsException() {
         when(workerRepository.findByUserEmailAndCompanyId("worker@test.com", companyId)).thenReturn(Optional.of(worker));
 
-        assertThatThrownBy(() -> workerService.invite(new WorkerInviteRequest("worker@test.com", "OPERATOR")))
+        assertThatThrownBy(() -> workerService.invite(new WorkerInviteRequest("worker@test.com", WorkerRole.OPERATOR)))
                 .isInstanceOf(WorkerAlreadyExistsException.class);
     }
 
@@ -118,7 +118,7 @@ class WorkerServiceTest {
         when(workerRepository.findByIdAndCompanyId(workerId, companyId)).thenReturn(Optional.of(worker));
         when(workerRepository.save(any())).thenReturn(worker);
 
-        WorkerResponse response = workerService.changeRole(workerId, new ChangeRoleRequest("ANALYST"));
+        WorkerResponse response = workerService.changeRole(workerId, new ChangeRoleRequest(WorkerRole.ANALYST));
 
         assertThat(response).isNotNull();
         verify(workerRepository).save(worker);
@@ -131,7 +131,7 @@ class WorkerServiceTest {
         when(workerRepository.findByIdAndCompanyId(workerId, companyId)).thenReturn(Optional.of(worker));
         when(workerRepository.countByCompanyIdAndRole(companyId, WorkerRole.COMPANY_ADMIN)).thenReturn(1L);
 
-        assertThatThrownBy(() -> workerService.changeRole(workerId, new ChangeRoleRequest("ANALYST")))
+        assertThatThrownBy(() -> workerService.changeRole(workerId, new ChangeRoleRequest(WorkerRole.ANALYST)))
                 .isInstanceOf(LastAdminException.class);
     }
 
@@ -169,7 +169,7 @@ class WorkerServiceTest {
     void invite_existingLoyalUser_throws() {
         when(workerRepository.findByUserEmailAndCompanyId("worker@test.com", companyId)).thenReturn(Optional.empty());
         when(loyalUserRepository.findByEmail("worker@test.com")).thenReturn(List.of(new LoyalUser()));
-        assertThatThrownBy(() -> workerService.invite(new WorkerInviteRequest("worker@test.com", "OPERATOR")))
+        assertThatThrownBy(() -> workerService.invite(new WorkerInviteRequest("worker@test.com", WorkerRole.OPERATOR)))
                 .isInstanceOf(LoyalUserCannotBeWorkerException.class);
     }
 

--- a/frontend/src/__tests__/ApiKeysSection.spec.js
+++ b/frontend/src/__tests__/ApiKeysSection.spec.js
@@ -97,11 +97,26 @@ describe('ApiKeysSection', () => {
       { id: 'k', name: 'k1', prefix: 'dlv_a', createdAt: '2026-01-01' },
     ] })
     mockDel.mockResolvedValueOnce({ ok: true })
+    const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
     const w = makeWrapper()
     await flushPromises()
 
     await w.vm.revoke('k')
     expect(mockDel).toHaveBeenCalledWith('/settings/api-keys/k')
+    confirmSpy.mockRestore()
+  })
+
+  it('does not revoke if confirm is cancelled', async () => {
+    mockGet.mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: 'k', name: 'k1', prefix: 'dlv_a', createdAt: '2026-01-01' },
+    ] })
+    const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+    const w = makeWrapper()
+    await flushPromises()
+
+    await w.vm.revoke('k')
+    expect(mockDel).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
   })
 
   it('copies token to clipboard', async () => {

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -511,3 +511,4 @@ apiKeys:
   active: Active
   revoked: Revoked
   revoke: Revoke
+  revokeConfirm: Revoke this API key? Any integrations using it will stop working.

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -415,6 +415,8 @@ error:
   CURRENT_PASSWORD_INVALID: Current password is incorrect
   NEW_PASSWORD_SAME_AS_CURRENT: New password cannot be the same as the current one
   VALIDATION_ERROR: Validation error
+  INVALID_NUMBER_FORMAT: "Invalid number format. Use a dot as the decimal separator (e.g. 40.4168)"
+  FILE_TOO_LARGE: The image exceeds the maximum allowed size
   INTERNAL_ERROR: Internal server error
   HANDLE_CONFLICT: This organization code is already in use
   handleInvalid: "Only lowercase letters, numbers and hyphens (cannot start or end with a hyphen)"

--- a/frontend/src/locales/en.yml
+++ b/frontend/src/locales/en.yml
@@ -165,6 +165,7 @@ units:
   new: New unit
   edit: Edit unit
   detail: Unit details
+  notFound: Unit not found
   defaultPriority: Default priority (overrides company)
   defaultPriorityHelp: If empty, the company default priority is used
   priorityOverridden: Overridden
@@ -292,6 +293,7 @@ tracking:
 loyalUsers:
   title: Loyal users
   new: Add loyal user
+  notFound: Loyal user not found
   empty: No loyal users with orders yet.
   email: Email
   registered: Registered

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -165,6 +165,7 @@ units:
   new: Nueva unidad
   edit: Editar unidad
   detail: Detalles de la unidad
+  notFound: Unidad no encontrada
   defaultPriority: Prioridad por defecto (sobreescribe la de la empresa)
   defaultPriorityHelp: Si se deja vacío se usa la prioridad por defecto de la empresa
   priorityOverridden: Sobreescrita
@@ -292,6 +293,7 @@ tracking:
 loyalUsers:
   title: Usuarios fidelizados
   new: Añadir fidelizado
+  notFound: Usuario fidelizado no encontrado
   empty: No hay usuarios fidelizados con pedidos todavía.
   email: Email
   registered: Registrado

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -415,6 +415,8 @@ error:
   CURRENT_PASSWORD_INVALID: La contraseña actual es incorrecta
   NEW_PASSWORD_SAME_AS_CURRENT: La nueva contraseña no puede ser igual a la actual
   VALIDATION_ERROR: Error de validación
+  INVALID_NUMBER_FORMAT: "Formato de número incorrecto. Usa el punto como separador decimal (ej. 40.4168)"
+  FILE_TOO_LARGE: La imagen supera el tamaño máximo permitido
   INTERNAL_ERROR: Error interno del servidor
   HANDLE_CONFLICT: Este código de organización ya está en uso
   handleInvalid: "Solo letras minúsculas, números y guiones (sin empezar ni terminar con guión)"

--- a/frontend/src/locales/es.yml
+++ b/frontend/src/locales/es.yml
@@ -511,3 +511,4 @@ apiKeys:
   active: Activa
   revoked: Revocada
   revoke: Revocar
+  revokeConfirm: "¿Revocar esta API key? Las integraciones que la estén usando dejarán de funcionar."

--- a/frontend/src/views/loyal-users/LoyalUserDetailView.vue
+++ b/frontend/src/views/loyal-users/LoyalUserDetailView.vue
@@ -81,6 +81,10 @@ onMounted(async () => {
       const list = await luRes.json()
       loyalUser.value = list.find(l => l.id === route.params.id) || null
     }
+    // Si no encontramos el fidelizado mostrar error en lugar de la ficha vacía
+    if (!loyalUser.value) {
+      error.value = t('loyalUsers.notFound')
+    }
   } catch {
     error.value = t('error.connection')
   } finally {

--- a/frontend/src/views/profile/ApiKeysSection.vue
+++ b/frontend/src/views/profile/ApiKeysSection.vue
@@ -84,6 +84,8 @@ function dismissCreated() {
 }
 
 async function revoke(id) {
+  // Evita revocar accidentalmente la clave en uso por una integración activa.
+  if (!globalThis.confirm(t('apiKeys.revokeConfirm'))) return
   revokingId.value = id
   revokeError.value = ''
   try {

--- a/frontend/src/views/profile/SettingsView.vue
+++ b/frontend/src/views/profile/SettingsView.vue
@@ -510,7 +510,7 @@ async function copyHandle() {
                 <p class="edit-form-title">{{ t('settings.editOrg') }}</p>
                 <div class="form-field">
                   <label>{{ t('fields.orgName') }}</label>
-                  <InputText v-model="orgName" :placeholder="t('fields.orgNamePlaceholder')" :invalid="!!invalids.orgName" fluid />
+                  <InputText v-model="orgName" :placeholder="t('fields.orgNamePlaceholder')" maxlength="255" :invalid="!!invalids.orgName" fluid />
                   <small v-if="vErrors.orgName" class="field-error">{{ vErrors.orgName }}</small>
                 </div>
                 <div class="form-field">
@@ -568,7 +568,7 @@ async function copyHandle() {
                       </div>
                       <div class="form-field">
                         <label>{{ t('fields.companyName') }}</label>
-                        <InputText v-model="companyName" :placeholder="t('fields.companyNamePlaceholder')" :invalid="!!invalids.companyName" fluid />
+                        <InputText v-model="companyName" :placeholder="t('fields.companyNamePlaceholder')" maxlength="255" :invalid="!!invalids.companyName" fluid />
                         <small v-if="vErrors.companyName" class="field-error">{{ vErrors.companyName }}</small>
                       </div>
                       <div class="form-field">
@@ -648,7 +648,7 @@ async function copyHandle() {
                 <div v-if="addingCompany" class="add-company-form">
                   <div class="form-field">
                     <label>{{ t('fields.companyName') }}</label>
-                    <InputText v-model="newCompanyName" :placeholder="t('fields.companyNamePlaceholder')" fluid />
+                    <InputText v-model="newCompanyName" :placeholder="t('fields.companyNamePlaceholder')" maxlength="255" fluid />
                   </div>
                   <div class="form-field">
                     <label>{{ t('fields.type') }}</label>

--- a/frontend/src/views/units/UnitDetailView.vue
+++ b/frontend/src/views/units/UnitDetailView.vue
@@ -43,6 +43,7 @@ async function load() {
   try {
     const res = await api.get(`/units/${route.params.id}`)
     if (res.ok) unit.value = await res.json()
+    else if (res.status === 404 || res.status === 400) error.value = t('units.notFound')
     else error.value = t('error.connection')
   } catch {
     error.value = t('error.connection')

--- a/frontend/src/views/units/UnitFormView.vue
+++ b/frontend/src/views/units/UnitFormView.vue
@@ -232,6 +232,7 @@ function handleSubmit() {
             id="unit-name"
             v-model="name"
             :placeholder="t('fields.unitNamePlaceholder')"
+            maxlength="255"
             :invalid="!!invalids.name"
             fluid
           />
@@ -246,6 +247,7 @@ function handleSubmit() {
               v-model="address"
               :placeholder="t('fields.addressPlaceholder')"
               :disabled="locationLocked"
+              maxlength="500"
               fluid
               @keydown.enter.prevent="!locationLocked && geocodeAddress()"
             />

--- a/frontend/src/views/workers/InviteWorkerView.vue
+++ b/frontend/src/views/workers/InviteWorkerView.vue
@@ -90,7 +90,7 @@ function copyPassword() {
         <div class="invite-form">
           <div class="form-field">
             <label>{{ t('workers.email') }}</label>
-            <InputText v-model="email" type="email" :placeholder="t('fields.emailPlaceholder')" :invalid="!!error && !email.trim()" @input="error = ''" fluid />
+            <InputText v-model="email" type="email" :placeholder="t('fields.emailPlaceholder')" maxlength="255" :invalid="!!error && !email.trim()" @input="error = ''" fluid />
           </div>
           <div class="form-field">
             <label>{{ t('workers.role') }}</label>


### PR DESCRIPTION
Hallazgos del informe de revisión defensiva (validaciones, permisos y mensajes de error). 6 commits.

## Críticos
- **C1** `WorkerInviteRequest.role` ahora es `WorkerRole` enum: rol inválido devuelve 400 limpio en lugar de 500
- **C2** Validar tamaño de avatar/logo contra `app.file.max-upload-bytes` (2 MB). Nueva `FileTooLargeException` mapeada a 413
- **C3** `LoyalUserDetailView` muestra "Usuario fidelizado no encontrado" cuando el id no existe (antes renderizaba ficha vacía)

## Importantes
- **I1** `UnitDetailView` traduce 404/400 a "Unidad no encontrada" en lugar de "Error de conexión"
- **I2** `maxlength` añadido a inputs faltantes en SettingsView (orgName, companyName, newCompanyName), InviteWorkerView (email) y UnitFormView (name, address)
- **I3** Confirmación con `confirm()` antes de revocar una API key + 1 test
- **I4** Handler distingue `InvalidFormatException` numérica → código `INVALID_NUMBER_FORMAT` con mensaje específico sobre el separador decimal (es/en)

## Verificación
- `mvn test` 157/157 OK
- `npm run lint` limpio
- `npm run test:unit` 60/60 OK